### PR TITLE
refactor: adopt pivac_config namespace, importlib, and pivac. module …

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ python scripts/pivac-provider.py pivac.OneWireTherm pivac.TED5000 --daemon
 2. `/etc/pivac/config.yml` (system install)
 3. `config/config.yml` (git clone)
 
-**Important:** `/etc/pivac/config.yml` must include a `signalk:` section with `host`, `port`, `username`, and `password` for the WebSocket connection to work. See `config/config.yml.sample` for the format.
+**Important:** `/etc/pivac/config.yml` must include a `pivac_config:` section containing a nested `signalk:` block with `host`, `port`, `username`, and `password` for the WebSocket connection to work. See `config/config.yml.sample` for the format.
 
 **Testing a module standalone** (no Signal K needed — outputs plain JSON to stdout):
 ```bash
@@ -45,7 +45,7 @@ python -c "import pivac.ArduinoPSI as m; import json; print(json.dumps(m.status(
 
 ### Module System
 
-Each sensor type is a standalone module in `pivac/`. The orchestrator (`scripts/pivac-provider.py`) dynamically loads modules listed in `config.yml` using `pydoc.safeimport()` and calls their `status()` function.
+Each sensor type is a standalone module in `pivac/`. The orchestrator (`scripts/pivac-provider.py`) dynamically loads modules listed in `config.yml` using `importlib.import_module()` and calls their `status()` function. Only keys starting with `pivac.` are treated as modules; `pivac_config:` is reserved for framework settings.
 
 **Every module must implement:**
 ```python

--- a/README.md
+++ b/README.md
@@ -102,15 +102,18 @@ sudo nano /etc/pivac/config.yml
 
 Each top-level key in the config file is an actual Python package name — so if you create your own Python packages and name them in the config file, they will be automatically discovered and used by the scripts. Enable or disable modules by setting `enabled: true/false`. A complete, commented sample is provided as `config/config.yml.sample`.
 
-**Signal K integration** requires a `signalk:` section in your config file with the host, port, and credentials for your Signal K server:
+**Signal K integration** requires a `pivac_config:` section in your config file containing the SignalK host, port, and credentials:
 
 ```yaml
-signalk:
-    host: localhost
-    port: 3000
-    username: admin
-    password: yourpassword
+pivac_config:
+    signalk:
+        host: localhost
+        port: 3000
+        username: admin
+        password: yourpassword
 ```
+
+Note: `pivac_config` is a reserved key for framework settings — it is not treated as a provider module.
 
 # Using the Package
 
@@ -159,6 +162,102 @@ The pivac package currently contains the following modules:
 * ArduinoPSI
 * ArduinoThermPSI
 * FlirFX (disabled by default)
+
+## Adding a New Provider Module
+
+Pivac is designed so that new data providers can be added without modifying any framework code. The steps are:
+
+**1. Write the module**
+
+Create `pivac/MyModule.py`. The module must implement a `status()` function with this signature:
+
+```python
+def status(config={}, output="default"):
+    ...
+```
+
+- When `output="default"`: return a plain Python dict of sensor readings (used for command-line testing)
+- When `output="signalk"`: return a Signal K delta dict built using the pivac helper functions:
+
+```python
+from pivac import sk_init_deltas, sk_add_source, sk_add_value
+
+deltas = sk_init_deltas()
+source = sk_add_source(deltas)
+sk_add_value(source, "environment.inside.myreading", value)
+return deltas
+```
+
+- On error: log a warning and return an empty delta — don't raise an exception, so the service keeps running
+- The module name must start with `pivac.` (e.g. `pivac.MyModule`)
+
+You can use the `propagate_defaults()` helper to copy top-level config values down to each entry in `inputs:` — see `GPIO.py` or `OneWireTherm.py` for examples.
+
+**2. Add a config section**
+
+Add a section to `/etc/pivac/config.yml` using the module's full Python name as the key:
+
+```yaml
+pivac.MyModule:
+    description: My new sensor module
+    enabled: true
+    daemon_sleep: 5
+    # ... module-specific config keys ...
+```
+
+**3. Test standalone**
+
+Verify the module works before connecting it to Signal K:
+
+```bash
+source ~/pivac-venv/bin/activate
+python scripts/pivac-provider.py pivac.MyModule --format pretty
+```
+
+This outputs the raw JSON to stdout without needing Signal K running.
+
+**4. Create a systemd service file**
+
+Copy an existing service file and adapt it:
+
+```bash
+cp scripts/systemd/pivac-gpio.service scripts/systemd/pivac-mymodule.service
+```
+
+Edit the new file — change the `Description` and the module name in `ExecStart`:
+
+```ini
+[Unit]
+Description=Pivac MyModule provider
+After=network.target signalk.service
+Requires=signalk.service
+
+[Service]
+Type=simple
+User=pi
+Environment=PIVAC_CFG=/etc/pivac/config.yml
+ExecStart=/home/pi/pivac-venv/bin/python3 /home/pi/github/pivac/scripts/pivac-provider.py pivac.MyModule --loglevel ERROR --daemon
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+```
+
+**5. Install and start the service**
+
+```bash
+sudo cp scripts/systemd/pivac-mymodule.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable pivac-mymodule
+sudo systemctl start pivac-mymodule
+```
+
+**6. Verify**
+
+```bash
+journalctl -u pivac-mymodule -n 50 --no-pager
+```
 
 ## Initialization
 * **`pivac.set_config(configfile="")`**: This method must be called before using any of the modules. It locates and reads the config file, first in `/etc/pivac/config.yml` then in `config/config.yml` relative to the parent directory of the scripts, if you do not specify it. Returns the `config` dictionary. This currently can only be set once, because the data read from the config file is used to load modules by the `pivac-provider.py` script. If you attempt to set again it will return the current config dict.

--- a/config/config.yml.sample
+++ b/config/config.yml.sample
@@ -130,14 +130,17 @@ pivac.RedLink:
             sk_path: environment.inside.thermostat
         outdoor_sensor:
             sk_path: environment.outside.thermostat
-# SignalK WebSocket connection settings.
-# pivac-provider.py uses these to push delta messages directly to SignalK via WebSocket,
-# replacing the v1 pipedProviders model. Create an admin user in SignalK if needed.
-signalk:
-    host: localhost
-    port: 3000
-    username: admin
-    password: xxx
+# Framework settings — not a module. Holds non-module configuration such as
+# the SignalK WebSocket connection. Keys here will not be treated as provider modules.
+pivac_config:
+    # SignalK WebSocket connection settings.
+    # pivac-provider.py uses these to push delta messages directly to SignalK via WebSocket.
+    # Create an admin user in SignalK if needed.
+    signalk:
+        host: localhost
+        port: 3000
+        username: admin
+        password: xxx
 
 pivac.FlirFX:
     description: Reports temperature and humidity data from a FLIRfx camera

--- a/scripts/pivac-provider.py
+++ b/scripts/pivac-provider.py
@@ -4,11 +4,8 @@ logger = logging.getLogger(__name__)
 import sys
 import argparse
 import json
-import socket
 import time
-import re
-import pkgutil
-from pydoc import safeimport
+import importlib
 import os
 import urllib.request
 import websocket
@@ -33,10 +30,13 @@ config = pivac.set_config(cfgfile)
 packages = config["packages"]
 
 # get list of modules in pivac that implement status()
-# skip the reserved "signalk" key which holds connection config
+# skip the reserved "pivac_config" key which holds framework settings
 pkglist = []
 for k in packages.keys():
-    if k == "signalk":
+    if k == "pivac_config":
+        continue
+    if not k.startswith("pivac."):
+        logger.warning("Config key '%s' does not start with 'pivac.' — skipping (not a pivac module)" % k)
         continue
     if "enabled" not in packages[k] or packages[k]["enabled"]:
         pkglist.append(k)
@@ -76,15 +76,18 @@ modfuncs = {}
 for p in args.stype:
     try:
         logger.debug("Loading module %s" % p)
-        statmod = safeimport(p)
+        statmod = importlib.import_module(p)
         statfn = getattr(statmod, "status")
         modfuncs[p] = statfn
-    except:
-        logger.exception("Package %s in configfile %s not found or doesn't have status() function" % (p, config["sourcefile"]))
+    except ImportError as e:
+        logger.error("Module %s not found: %s" % (p, e))
+        sys.exit(1)
+    except AttributeError:
+        logger.error("Module %s does not implement a status() function" % p)
         sys.exit(1)
 
 # SignalK WebSocket connection helpers
-sk_config = packages.get("signalk", {})
+sk_config = packages.get("pivac_config", {}).get("signalk", {})
 
 def get_sk_token(sk_cfg):
     """Fetch a JWT token from the SignalK auth endpoint."""
@@ -129,7 +132,7 @@ ws = None
 if sk_config:
     ws = reconnect_sk_ws(sk_config, None)
 else:
-    logger.warning("No 'signalk' section in config — falling back to stdout output.")
+    logger.warning("No 'pivac_config.signalk' section in config — falling back to stdout output.")
 
 sleepytime = -1
 packages = config["packages"]


### PR DESCRIPTION
…enforcement

- scripts/pivac-provider.py: replace pydoc.safeimport with importlib.import_module, skip pivac_config: key instead of signalk:, enforce pivac. namespace on module keys, read SignalK config from pivac_config.signalk instead of top-level signalk:
- config/config.yml.sample: nest signalk: block under new pivac_config: reserved key
- README.md: update SignalK config example; add comprehensive "Adding a New Provider Module" section with code, config, testing, systemd, and deployment steps
- CLAUDE.md: update signalk: reference to pivac_config.signalk; update pydoc.safeimport reference to importlib; document pivac. namespace enforcement