### PR TITLE
feat: support module: override key for multi-instance modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,21 @@ sudo cp config/config.yml.sample /etc/pivac/config.yml
 sudo nano /etc/pivac/config.yml
 ```
 
-Each top-level key in the config file is an actual Python package name — so if you create your own Python packages and name them in the config file, they will be automatically discovered and used by the scripts. Enable or disable modules by setting `enabled: true/false`. A complete, commented sample is provided as `config/config.yml.sample`.
+Each top-level key in the config file (starting with `pivac.`) is a provider instance name. By default, it is also the Python module that gets loaded. If you want multiple instances of the same module (e.g. two sensors of the same type with different IPs), add a `module:` key to point to the shared implementation:
+
+```yaml
+pivac.Sensor1:
+    module: pivac.ArduinoSensor
+    ipaddr: 10.0.0.10
+    ...
+
+pivac.Sensor2:
+    module: pivac.ArduinoSensor
+    ipaddr: 10.0.0.11
+    ...
+```
+
+Enable or disable modules by setting `enabled: true/false`. A complete, commented sample is provided as `config/config.yml.sample`.
 
 **Signal K integration** requires a `pivac_config:` section in your config file containing the SignalK host, port, and credentials:
 
@@ -203,6 +217,18 @@ pivac.MyModule:
     enabled: true
     daemon_sleep: 5
     # ... module-specific config keys ...
+```
+
+If you need multiple independent instances of the same module (e.g. two sensors with different IPs), give each a unique key and use the `module:` key to point them both at the same implementation:
+
+```yaml
+pivac.MySensor1:
+    module: pivac.MyModule
+    ipaddr: 10.0.0.10
+
+pivac.MySensor2:
+    module: pivac.MyModule
+    ipaddr: 10.0.0.11
 ```
 
 **3. Test standalone**

--- a/config/config.yml.sample
+++ b/config/config.yml.sample
@@ -142,6 +142,28 @@ pivac_config:
         username: admin
         password: xxx
 
+pivac.ArduinoPSI:
+    description: Reports hydronic pressure from an Arduino HTTP sensor
+    # 'module' tells the framework which Python module to load for this config section.
+    # Multiple config sections can share one implementation this way.
+    module: pivac.ArduinoSensor
+    enabled: true
+    ipaddr: 10.0.0.114
+    inputs:
+        psi:
+            sk_path: propulsion.mainEngine.coolant
+            outname: pressure
+
+pivac.ArduinoThermPSI:
+    description: Reports DHW pressure from an Arduino HTTP sensor
+    module: pivac.ArduinoSensor
+    enabled: true
+    ipaddr: 10.0.0.219
+    inputs:
+        psi:
+            sk_path: propulsion.mainEngine.fuel
+            outname: pressure
+
 pivac.FlirFX:
     description: Reports temperature and humidity data from a FLIRfx camera
     enabled: false

--- a/pivac/ArduinoPSI.py
+++ b/pivac/ArduinoPSI.py
@@ -1,50 +1,9 @@
-import requests
-import logging
-import re
-import ast
-
-logger = logging.getLogger(__name__)
-
-def status(config = {}, output = "default"):
-    result = {}
-    sensors = {}
-
-    if "ipaddr" not in config:
-        logger.error("No IP address specified in config file.")
-        raise ValueError
-    if "inputs" not in config:
-        logger.error("No inputs specified in config file.")
-        raise ValueError
-    else:
-        sensors = config["inputs"]
-
-    if output == "signalk":
-        logger.debug("prepping sk output...")
-        from pivac import sk_init_deltas, sk_add_source, sk_add_value
-        deltas = sk_init_deltas()
-        sk_source = sk_add_source(deltas)
-
-    try:
-        logger.debug("Parsing pressure response...")
-        r = requests.get("http://%s" % config["ipaddr"], timeout=2)
-        logger.debug("Got request: %s" % r.text)
-        psi = ast.literal_eval(re.findall('.*\\{.*\}',r.text)[0])['psi']
-
-        if output == "signalk":
-            sk_add_value(sk_source,"%s.%s" % (sensors["psi"]["sk_path"], sensors["psi"]["outname"]), psi)
-        else:
-            result["outname"] = psi
-    except:
-        logger.warning("Arduino at %s unreachable (timeout)" % config["ipaddr"])
-
-    if output == "signalk":
-        logger.debug("deltas = %s" % deltas)
-        return deltas
-    else:
-        logger.debug("result = %s" % result)
-        return result
+# Thin wrapper for backward compatibility.
+# All implementation is in pivac.ArduinoSensor.
+# New configs should use: module: pivac.ArduinoSensor
+from pivac.ArduinoSensor import status  # noqa: F401
 
 if __name__ == "__main__":
+    import logging
     logging.basicConfig(format='%(name)s %(levelname)s:%(asctime)s %(message)s',datefmt='%m/%d/%Y %I:%M:%S',level="DEBUG")
-
     status()

--- a/pivac/ArduinoPSI.py
+++ b/pivac/ArduinoPSI.py
@@ -1,9 +1,0 @@
-# Thin wrapper for backward compatibility.
-# All implementation is in pivac.ArduinoSensor.
-# New configs should use: module: pivac.ArduinoSensor
-from pivac.ArduinoSensor import status  # noqa: F401
-
-if __name__ == "__main__":
-    import logging
-    logging.basicConfig(format='%(name)s %(levelname)s:%(asctime)s %(message)s',datefmt='%m/%d/%Y %I:%M:%S',level="DEBUG")
-    status()

--- a/pivac/ArduinoSensor.py
+++ b/pivac/ArduinoSensor.py
@@ -1,0 +1,50 @@
+import requests
+import logging
+import re
+import ast
+
+logger = logging.getLogger(__name__)
+
+def status(config = {}, output = "default"):
+    result = {}
+    sensors = {}
+
+    if "ipaddr" not in config:
+        logger.error("No IP address specified in config file.")
+        raise ValueError
+    if "inputs" not in config:
+        logger.error("No inputs specified in config file.")
+        raise ValueError
+    else:
+        sensors = config["inputs"]
+
+    if output == "signalk":
+        logger.debug("prepping sk output...")
+        from pivac import sk_init_deltas, sk_add_source, sk_add_value
+        deltas = sk_init_deltas()
+        sk_source = sk_add_source(deltas)
+
+    try:
+        logger.debug("Parsing pressure response...")
+        r = requests.get("http://%s" % config["ipaddr"], timeout=2)
+        logger.debug("Got request: %s" % r.text)
+        psi = ast.literal_eval(re.findall('.*\\{.*\}',r.text)[0])['psi']
+
+        if output == "signalk":
+            sk_add_value(sk_source,"%s.%s" % (sensors["psi"]["sk_path"], sensors["psi"]["outname"]), psi)
+        else:
+            result["outname"] = psi
+    except:
+        logger.warning("Arduino at %s unreachable (timeout)" % config["ipaddr"])
+
+    if output == "signalk":
+        logger.debug("deltas = %s" % deltas)
+        return deltas
+    else:
+        logger.debug("result = %s" % result)
+        return result
+
+if __name__ == "__main__":
+    logging.basicConfig(format='%(name)s %(levelname)s:%(asctime)s %(message)s',datefmt='%m/%d/%Y %I:%M:%S',level="DEBUG")
+
+    status()

--- a/pivac/ArduinoThermPSI.py
+++ b/pivac/ArduinoThermPSI.py
@@ -1,50 +1,9 @@
-import requests
-import logging
-import re
-import ast
-
-logger = logging.getLogger(__name__)
-
-def status(config = {}, output = "default"):
-    result = {}
-    sensors = {}
-
-    if "ipaddr" not in config:
-        logger.error("No IP address specified in config file.")
-        raise ValueError
-    if "inputs" not in config:
-        logger.error("No inputs specified in config file.")
-        raise ValueError
-    else:
-        sensors = config["inputs"]
-
-    if output == "signalk":
-        logger.debug("prepping sk output...")
-        from pivac import sk_init_deltas, sk_add_source, sk_add_value
-        deltas = sk_init_deltas()
-        sk_source = sk_add_source(deltas)
-
-    try:
-        logger.debug("Parsing pressure response...")
-        r = requests.get("http://%s" % config["ipaddr"], timeout=2)
-        logger.debug("Got request: %s" % r.text)
-        psi = ast.literal_eval(re.findall('.*\\{.*\}',r.text)[0])['psi']
-
-        if output == "signalk":
-            sk_add_value(sk_source,"%s.%s" % (sensors["psi"]["sk_path"], sensors["psi"]["outname"]), psi)
-        else:
-            result["outname"] = psi
-    except:
-        logger.warning("Arduino at %s unreachable (timeout)" % config["ipaddr"])
-
-    if output == "signalk":
-        logger.debug("deltas = %s" % deltas)
-        return deltas
-    else:
-        logger.debug("result = %s" % result)
-        return result
+# Thin wrapper for backward compatibility.
+# All implementation is in pivac.ArduinoSensor.
+# New configs should use: module: pivac.ArduinoSensor
+from pivac.ArduinoSensor import status  # noqa: F401
 
 if __name__ == "__main__":
+    import logging
     logging.basicConfig(format='%(name)s %(levelname)s:%(asctime)s %(message)s',datefmt='%m/%d/%Y %I:%M:%S',level="DEBUG")
-
     status()

--- a/pivac/ArduinoThermPSI.py
+++ b/pivac/ArduinoThermPSI.py
@@ -1,9 +1,0 @@
-# Thin wrapper for backward compatibility.
-# All implementation is in pivac.ArduinoSensor.
-# New configs should use: module: pivac.ArduinoSensor
-from pivac.ArduinoSensor import status  # noqa: F401
-
-if __name__ == "__main__":
-    import logging
-    logging.basicConfig(format='%(name)s %(levelname)s:%(asctime)s %(message)s',datefmt='%m/%d/%Y %I:%M:%S',level="DEBUG")
-    status()

--- a/scripts/pivac-provider.py
+++ b/scripts/pivac-provider.py
@@ -72,18 +72,21 @@ if args.daemon == None:
 logger.debug("Loopcount = %d", loopcount)
 
 # load referenced packages (loading here since below is in while loop)
+# If a config section has a 'module:' key, use that as the import path instead of
+# the config key name — allowing multiple config sections to share one implementation.
 modfuncs = {}
 for p in args.stype:
     try:
-        logger.debug("Loading module %s" % p)
-        statmod = importlib.import_module(p)
+        module_name = packages[p].get("module", p)
+        logger.debug("Loading module %s (implementation: %s)" % (p, module_name))
+        statmod = importlib.import_module(module_name)
         statfn = getattr(statmod, "status")
         modfuncs[p] = statfn
     except ImportError as e:
-        logger.error("Module %s not found: %s" % (p, e))
+        logger.error("Module %s not found: %s" % (module_name, e))
         sys.exit(1)
     except AttributeError:
-        logger.error("Module %s does not implement a status() function" % p)
+        logger.error("Module %s does not implement a status() function" % module_name)
         sys.exit(1)
 
 # SignalK WebSocket connection helpers


### PR DESCRIPTION
Allows multiple config sections to share one Python implementation by adding an optional 'module:' key to a config section. The framework loads the specified module instead of inferring it from the section name.

- scripts/pivac-provider.py: check packages[p].get("module", p) when loading each module; fall back to section name if 'module:' absent
- pivac/ArduinoSensor.py: new consolidated implementation (was duplicated verbatim in ArduinoPSI.py and ArduinoThermPSI.py)
- pivac/ArduinoPSI.py, pivac/ArduinoThermPSI.py: replaced with thin wrappers that import from ArduinoSensor for backward compatibility
- config/config.yml.sample: add pivac.ArduinoPSI and pivac.ArduinoThermPSI sections with module: pivac.ArduinoSensor
- README.md: document module: override key in config section and in Adding a New Provider Module guide