### PR TITLE
fix(ArduinoSensor): use raw string for regex to silence SyntaxWarning

### DIFF
--- a/pivac/ArduinoSensor.py
+++ b/pivac/ArduinoSensor.py
@@ -28,7 +28,7 @@ def status(config = {}, output = "default"):
         logger.debug("Parsing pressure response...")
         r = requests.get("http://%s" % config["ipaddr"], timeout=2)
         logger.debug("Got request: %s" % r.text)
-        psi = ast.literal_eval(re.findall('.*\\{.*\}',r.text)[0])['psi']
+        psi = ast.literal_eval(re.findall(r'.*\{.*\}',r.text)[0])['psi']
 
         if output == "signalk":
             sk_add_value(sk_source,"%s.%s" % (sensors["psi"]["sk_path"], sensors["psi"]["outname"]), psi)


### PR DESCRIPTION
## Summary
- `re.findall('.*\\{.*\}', ...)` generates a `SyntaxWarning` on Python 3.12+ because `\}` is not a valid escape sequence in a regular string
- Changed to `re.findall(r'.*\{.*\}', ...)` — equivalent regex, no warning

## Test plan
- [ ] Confirm no `SyntaxWarning` in `journalctl` output after restarting `pivac-arduino-psi` and `pivac-arduino-therm-psi`
- [ ] Confirm PSI values still flowing in Signal K after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)