### PR TITLE
Fix ArduinoSensor result key, error handling, and add parser comment

### DIFF
--- a/pivac/ArduinoSensor.py
+++ b/pivac/ArduinoSensor.py
@@ -28,14 +28,21 @@ def status(config = {}, output = "default"):
         logger.debug("Parsing pressure response...")
         r = requests.get("http://%s" % config["ipaddr"], timeout=2)
         logger.debug("Got request: %s" % r.text)
+        # The Arduino returns single-quoted pseudo-JSON (e.g. {'psi' : 18.4}) wrapped in
+        # HTML boilerplate. We extract the dict-like line with a regex, then parse it with
+        # ast.literal_eval (not json.loads) because single-quoted keys are valid Python
+        # literals but not valid JSON. Do not change to json.loads without also updating
+        # the Arduino sketches to emit double-quoted keys.
         psi = ast.literal_eval(re.findall(r'.*\{.*\}',r.text)[0])['psi']
 
         if output == "signalk":
             sk_add_value(sk_source,"%s.%s" % (sensors["psi"]["sk_path"], sensors["psi"]["outname"]), psi)
         else:
-            result["outname"] = psi
-    except:
+            result[sensors["psi"]["outname"]] = psi
+    except (requests.exceptions.Timeout, requests.exceptions.ConnectionError):
         logger.warning("Arduino at %s unreachable (timeout)" % config["ipaddr"])
+    except Exception as e:
+        logger.warning("Arduino at %s: failed to parse response: %s" % (config["ipaddr"], e))
 
     if output == "signalk":
         logger.debug("deltas = %s" % deltas)


### PR DESCRIPTION
Three targeted fixes:

1. result["outname"] was a hardcoded string literal instead of using the configured output name from sensors["psi"]["outname"]. This only affected default (non-Signal K) output, so production daemon mode was unaffected, but standalone testing returned a key named literally "outname".

2. Bare except: caught everything — including parse errors — and logged the misleading "unreachable (timeout)" message. Now distinguishes between connection/timeout failures (requests exceptions) and parse failures (everything else), with a more informative message for each case.

3. Added a comment explaining why ast.literal_eval is used instead of json.loads, and warning not to switch to json.loads without updating the Arduino sketches to emit double-quoted keys.