### PR TITLE
fix(redlink): add socket timeout to prevent multi-hour data gaps

### DIFF
--- a/config/config.yml.sample
+++ b/config/config.yml.sample
@@ -109,7 +109,13 @@ pivac.RedLink:
 
     # how long to sleep in sec between status calls. Default (if absent) is 0.5 sec
     daemon_sleep: 2
-    
+
+    # socket timeout in seconds per HTTP request to the Honeywell site. Default is 30.
+    # Prevents indefinite hangs when the server accepts a connection but stalls mid-response.
+    # Each scrape cycle makes 2 HTTP requests, so worst-case stall before giving up is
+    # request_timeout * 2. Keep this well above daemon_sleep.
+    request_timeout: 30
+
     # website
     site: "https://www.mytotalconnectcomfort.com/portal"
     

--- a/pivac/RedLink.py
+++ b/pivac/RedLink.py
@@ -1,5 +1,6 @@
 import ssl
 import http.client
+import socket
 
 # workaround for mechanize/Python 3.13 SSL compatibility
 # patch connect() so SSL verification is disabled immediately before the handshake,
@@ -96,6 +97,8 @@ def status(config={}, output="default"):
         homepage = config["website"]
     else:
         homepage = HOMEPAGE
+
+    socket.setdefaulttimeout(config.get("request_timeout", 30))
 
     if not "uid" in config or not "pwd" in config:
         logger.error("Credentials not specified in config file.")


### PR DESCRIPTION
## Summary

- Adds a `request_timeout` config key (default: 30s) to the RedLink module
- Calls `socket.setdefaulttimeout()` at the start of each `status()` call so all mechanize HTTP requests are bounded
- Documents the new key in `config/config.yml.sample` with guidance on how to size it

## Root cause

Log analysis showed the RedLink service hanging for 1–3+ hours between data points despite a 15-second `daemon_sleep`. The Honeywell server occasionally accepts a TCP connection but stalls mid-response. With no socket timeout set, Python blocks indefinitely on the socket read. The OS eventually tears down the stale connection via kernel-level TCP keepalive expiry (~60–120 min on Linux defaults), causing the hours-long gaps observed.

The fast-fail `ConnectionResetError` (already documented as a known operational behavior) is unaffected — that fails immediately at TLS handshake time and is not caused by this.

## Test plan

- [ ] Deploy to pivac, restart `pivac-redlink`, monitor logs — should see regular ERROR/recovery cycles at the ~60s worst-case ceiling rather than multi-hour gaps
- [ ] Verify `request_timeout: 30` can be added to `/etc/pivac/config.yml` under `pivac.RedLink` to make the timeout explicit in the live config

🤖 Generated with [Claude Code](https://claude.com/claude-code)