### PR TITLE
feat: add Emporia Vue power monitor module

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,7 @@ The Arduino pressure sensors (10.0.0.114 and 10.0.0.219) are programmed from a s
 | pivac-gpio              | pivac.GPIO              | GPIO input pins (relays/switches)| GPIO         |
 | pivac-arduino-psi       | pivac.ArduinoSensor     | Hydronic pressure (Fusch 100PSI) | 10.0.0.114   |
 | pivac-arduino-therm-psi | pivac.ArduinoSensor     | DHW pressure (Fusch 200PSI)      | 10.0.0.219   |
+| pivac-emporia           | pivac.Emporia           | Emporia Vue Gen 2 (house + apt)  | Emporia cloud |
 
 ## Key File Locations
 
@@ -142,6 +143,17 @@ root_url = https://68lookout.dglc.com/grafana/
 serve_from_sub_path = true
 ```
 If these are lost, Grafana will redirect to `/login` with an internal URL and break the proxy.
+
+## Emporia Setup (first time only)
+
+Before enabling `pivac-emporia.service`, run the discovery script to get device GIDs:
+```bash
+source ~/pivac-venv/bin/activate
+python ~/github/pivac/scripts/emporia-discover.py --username YOUR_EMAIL --password YOUR_PASSWORD
+```
+Copy the suggested config block into `/etc/pivac/config.yml`, replacing the GID placeholders with real values.
+
+Token is cached at `/etc/pivac/emporia-tokens.json` after first successful login.
 
 ## Standard Deployment Procedure
 
@@ -195,6 +207,7 @@ journalctl -u signalk -n 50 --no-pager
 | `RedLink` | Honeywell thermostat (web scraping) |
 | `FlirFX` | FLIR camera temperature/humidity — currently disabled |
 | `ArduinoSensor` | Arduino HTTP sensor (hydronic pressure, DHW pressure) — shared implementation for `pivac.ArduinoPSI` and `pivac.ArduinoThermPSI` config sections via `module:` override |
+| `Emporia` | Emporia Vue Gen 2 power monitors — polls two panels (house 200A, apartment 100A) via PyEmVue, emits per-circuit Watts to `electrical.emporia.<panel>.<circuit>` |
 
 ## Signal K Upgrade (if needed)
 

--- a/config/config.yml.sample
+++ b/config/config.yml.sample
@@ -203,6 +203,30 @@ pivac.ArduinoThermPSI:
 #             outname: reading_name   # used in Signal K path and default JSON output
 #             sk_path: environment.inside.mymodule   # override top-level sk_path if needed
 
+pivac.Emporia:
+    description: Reports power consumption from Emporia Vue energy monitors
+    enabled: true
+
+    # How long to sleep between polls in daemon mode. Emporia data at 1-minute
+    # scale doesn't update faster than once per minute, so 60s is appropriate.
+    daemon_sleep: 60
+
+    # Emporia account credentials. Token is cached at token_file so the
+    # password is only used on first run or when the cached token expires.
+    username: user@example.com
+    password: xxx
+    token_file: /etc/pivac/emporia-tokens.json
+
+    # Signal K base path. Each panel and circuit appends to this:
+    #   electrical.emporia.<panel_name>.<circuit_name>
+    sk_path: electrical.emporia
+
+    # Map device GIDs (from scripts/emporia-discover.py) to panel names.
+    # Panel names become part of the Signal K path.
+    panels:
+        "123456789": house        # 200A main panel
+        "987654321": apartment    # 100A apartment panel
+
 pivac.FlirFX:
     description: Reports temperature and humidity data from a FLIRfx camera
     enabled: false

--- a/pivac/Emporia.py
+++ b/pivac/Emporia.py
@@ -1,0 +1,174 @@
+import logging
+from datetime import datetime, timezone
+
+logger = logging.getLogger(__name__)
+
+# Module-level cache: authenticated PyEmVue instance and device properties.
+# Both persist across calls within a single daemon process, avoiding
+# re-authentication and re-discovery on every poll cycle.
+_vue = None
+_device_cache = {}  # gid (int) -> {'name': str, 'channels': {channel_num: channel_name}}
+
+
+def _sanitize(name):
+    """Convert a human-readable circuit name into a Signal K path component."""
+    return name.lower().replace(' ', '_').replace('/', '_').replace('-', '_').replace('(', '').replace(')', '')
+
+
+def _get_vue(config):
+    """Return (or create) an authenticated PyEmVue instance."""
+    global _vue
+    if _vue is not None:
+        return _vue
+    try:
+        import pyemvue
+        _vue = pyemvue.PyEmVue()
+        token_file = config.get('token_file', '/etc/pivac/emporia-tokens.json')
+        _vue.login(
+            username=config['username'],
+            password=config['password'],
+            token_storage_file=token_file
+        )
+        logger.info("Authenticated with Emporia API (token cached at %s)" % token_file)
+    except Exception as e:
+        logger.error("Failed to authenticate with Emporia: %s" % e)
+        _vue = None
+        raise
+    return _vue
+
+
+def _get_device_cache(vue, config):
+    """
+    Build (or return cached) a mapping of device GID to panel name and channel names.
+
+    Config 'panels' maps GID strings to friendly panel names, e.g.:
+        panels:
+            "123456789": house
+            "987654321": apartment
+
+    Channel names come from the Emporia app via populate_device_properties().
+    """
+    global _device_cache
+    if _device_cache:
+        return _device_cache
+
+    panels = config.get('panels', {})
+    devices = vue.get_devices()
+    vue.populate_device_properties(devices)
+
+    for device in devices:
+        gid = device.device_gid
+        panel_name = panels.get(str(gid), 'panel_%s' % gid)
+        channel_names = {}
+        if device.channels:
+            for ch in device.channels:
+                channel_names[ch.channel_num] = ch.name or ('channel_%s' % ch.channel_num)
+        _device_cache[gid] = {
+            'name': panel_name,
+            'channel_names': channel_names,
+        }
+        logger.info("Discovered Emporia device GID %s -> panel '%s' with %d channels" % (
+            gid, panel_name, len(channel_names)))
+
+    return _device_cache
+
+
+def status(config={}, output="default"):
+    """
+    Poll all configured Emporia panels and return current power readings in Watts.
+
+    Each channel (main feed legs + individual circuit clamps) becomes a separate
+    Signal K value at path:  <sk_path>.<panel_name>.<circuit_name>
+
+    Config keys:
+        username       Emporia account email
+        password       Emporia account password
+        token_file     Path for token cache (default: /etc/pivac/emporia-tokens.json)
+        sk_path        Signal K base path (default: electrical.emporia)
+        panels         Dict mapping GID strings to panel names
+                         e.g. {"123456789": "house", "987654321": "apartment"}
+    """
+    global _vue, _device_cache
+
+    for key in ('username', 'password'):
+        if key not in config:
+            logger.error("Emporia: '%s' required in config" % key)
+            raise ValueError("Emporia: '%s' required in config" % key)
+
+    result = {}
+
+    if output == "signalk":
+        from pivac import sk_init_deltas, sk_add_source, sk_add_value
+        deltas = sk_init_deltas()
+        sk_source = sk_add_source(deltas)
+
+    try:
+        from pyemvue.enums import Scale, Unit
+
+        vue = _get_vue(config)
+        cache = _get_device_cache(vue, config)
+        sk_base = config.get('sk_path', 'electrical.emporia')
+
+        gids = list(cache.keys())
+        devices_usage, timestamp = vue.get_device_list_usage(
+            deviceGids=gids,
+            instant=datetime.now(timezone.utc),
+            scale=Scale.MINUTE.value,
+            unit=Unit.WATTS.value
+        )
+
+        for gid, usage_device in devices_usage.items():
+            if gid not in cache:
+                logger.warning("Emporia: received data for unknown GID %s, skipping" % gid)
+                continue
+            if usage_device is None:
+                logger.warning("Emporia: no usage data returned for panel '%s' (GID %s)" % (
+                    cache[gid]['name'], gid))
+                continue
+
+            panel_name = cache[gid]['name']
+            channel_names = cache[gid]['channel_names']
+
+            for channel_num, channel in usage_device.channels.items():
+                if channel is None or channel.usage is None:
+                    continue
+
+                watts = round(channel.usage, 1)
+
+                # Use the cached channel name from populate_device_properties; fall back
+                # to the name on the usage object, then a generic label.
+                raw_name = (channel_names.get(channel_num)
+                            or getattr(channel, 'name', None)
+                            or 'channel_%s' % channel_num)
+                cname = _sanitize(raw_name)
+                sk_path = "%s.%s.%s" % (sk_base, panel_name, cname)
+
+                if output == "signalk":
+                    sk_add_value(sk_source, sk_path, watts)
+                    logger.debug("Emporia: %s = %s W" % (sk_path, watts))
+                else:
+                    result["%s.%s" % (panel_name, cname)] = watts
+
+    except Exception as e:
+        logger.error("Emporia: failed to get usage data: %s" % e)
+        # Reset caches to force re-auth and re-discovery on next poll cycle,
+        # in case the session expired or the device list changed.
+        _vue = None
+        _device_cache = {}
+
+    if output == "signalk":
+        logger.debug("deltas = %s" % deltas)
+        return deltas
+    else:
+        logger.debug("result = %s" % result)
+        return result
+
+
+if __name__ == "__main__":
+    import json
+    logging.basicConfig(
+        format='%(name)s %(levelname)s:%(asctime)s %(message)s',
+        datefmt='%m/%d/%Y %I:%M:%S',
+        level="DEBUG"
+    )
+    print(json.dumps(status(), indent=2))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "RPi.GPIO",
     "regex",
     "websocket-client",
+    "pyemvue",
 ]
 
 [project.urls]

--- a/scripts/emporia-discover.py
+++ b/scripts/emporia-discover.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""
+emporia-discover.py — List all Emporia devices and circuits on your account.
+
+Run this once to find your device GIDs and circuit names so you can populate
+the pivac.Emporia section in /etc/pivac/config.yml.
+
+Usage:
+    source ~/pivac-venv/bin/activate
+    python scripts/emporia-discover.py --username YOUR_EMAIL --password YOUR_PASSWORD
+
+Or, if PIVAC_CFG (or /etc/pivac/config.yml) already has a pivac.Emporia section
+with username/password filled in:
+    python scripts/emporia-discover.py
+"""
+
+import argparse
+import sys
+import os
+
+
+def load_credentials_from_config():
+    """Try to pull username/password from the pivac config file."""
+    try:
+        import yaml
+        cfg_file = os.environ.get('PIVAC_CFG', '/etc/pivac/config.yml')
+        with open(cfg_file, 'r') as f:
+            cfg = yaml.load(f.read(), Loader=yaml.FullLoader)
+        emporia_cfg = cfg.get('pivac.Emporia', {})
+        return emporia_cfg.get('username'), emporia_cfg.get('password')
+    except Exception:
+        return None, None
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Discover Emporia devices and circuit names')
+    parser.add_argument('--username', help='Emporia account email')
+    parser.add_argument('--password', help='Emporia account password')
+    args = parser.parse_args()
+
+    username = args.username
+    password = args.password
+
+    if not username or not password:
+        cfg_user, cfg_pass = load_credentials_from_config()
+        username = username or cfg_user
+        password = password or cfg_pass
+
+    if not username or not password:
+        print("ERROR: username and password are required.")
+        print("Provide --username / --password, or add them to pivac.Emporia in your config file.")
+        sys.exit(1)
+
+    try:
+        import pyemvue
+    except ImportError:
+        print("ERROR: pyemvue is not installed. Run: pip install pyemvue --break-system-packages")
+        sys.exit(1)
+
+    print("Authenticating with Emporia API...")
+    vue = pyemvue.PyEmVue()
+    try:
+        vue.login(username=username, password=password)
+    except Exception as e:
+        print("ERROR: Authentication failed: %s" % e)
+        sys.exit(1)
+
+    print("Fetching devices...\n")
+    devices = vue.get_devices()
+    vue.populate_device_properties(devices)
+
+    if not devices:
+        print("No devices found on this account.")
+        sys.exit(0)
+
+    print("Found %d device(s):\n" % len(devices))
+    print("=" * 60)
+
+    for device in devices:
+        print("Device: %s" % (device.device_name or "(unnamed)"))
+        print("  GID:            %s" % device.device_gid)
+        print("  Model:          %s" % (device.model or "unknown"))
+        print("  Firmware:       %s" % (device.firmware or "unknown"))
+        print("  Location:       %s" % (device.location_name or "unknown"))
+        print()
+
+        if device.channels:
+            print("  Channels:")
+            for ch in sorted(device.channels, key=lambda c: c.channel_num):
+                print("    [%2s]  %s" % (ch.channel_num, ch.name or "(unnamed)"))
+        else:
+            print("  No channels found (try running after a short delay)")
+        print()
+
+    print("=" * 60)
+    print()
+    print("Add the following to your /etc/pivac/config.yml:\n")
+    print("pivac.Emporia:")
+    print("    description: Reports power consumption from Emporia Vue panels")
+    print("    enabled: true")
+    print("    daemon_sleep: 60")
+    print("    username: %s" % username)
+    print("    password: YOUR_PASSWORD")
+    print("    token_file: /etc/pivac/emporia-tokens.json")
+    print("    sk_path: electrical.emporia")
+    print("    panels:")
+    for device in devices:
+        suggested_name = (device.location_name or device.device_name or 'panel').lower().replace(' ', '_')
+        print('        "%s": %s  # %s' % (
+            device.device_gid,
+            suggested_name,
+            device.device_name or "(unnamed)"
+        ))
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/systemd/pivac-emporia.service
+++ b/scripts/systemd/pivac-emporia.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Pivac Emporia Vue power monitor provider
+After=network.target signalk.service
+Requires=signalk.service
+
+[Service]
+Type=simple
+User=pi
+Environment=PIVAC_CFG=/etc/pivac/config.yml
+ExecStart=/home/pi/pivac-venv/bin/python3 /home/pi/github/pivac/scripts/pivac-provider.py pivac.Emporia --loglevel ERROR --daemon
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

- Adds `pivac/Emporia.py` — polls two Emporia Vue Gen 2 panels (house 200A, apartment 100A) via PyEmVue and emits per-circuit power readings in Watts to Signal K at `electrical.emporia.<panel>.<circuit>`
- Adds `scripts/emporia-discover.py` — run once on the Pi to get device GIDs and circuit names for config
- Adds `scripts/systemd/pivac-emporia.service` — systemd unit with 60s daemon sleep (matches Emporia's 1-minute data resolution)
- Updates `config/config.yml.sample` with a `pivac.Emporia` example block
- Adds `pyemvue` to `pyproject.toml` dependencies
- Updates `CLAUDE.md` with module entry, service table row, and first-time Emporia setup procedure

## Test plan

- [ ] Install pyemvue in pivac venv: `pip install pyemvue --break-system-packages`
- [ ] Run `scripts/emporia-discover.py` with Emporia credentials to confirm device GIDs and circuit names print correctly
- [ ] Add `pivac.Emporia` block to `/etc/pivac/config.yml` with real GIDs and panel names
- [ ] Test standalone: `python -c "import pivac.Emporia as m; import json; print(json.dumps(m.status(), indent=2))"`
- [ ] Test Signal K output: run `pivac-provider.py pivac.Emporia --loglevel DEBUG`
- [ ] Install and enable service, verify data appears in Signal K and Grafana

🤖 Generated with [Claude Code](https://claude.com/claude-code)