### PR TITLE
Fix Emporia populate_device_properties for newer pyemvue

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,7 +131,7 @@ All remote access goes through nginx on the Pi (`10.0.0.82`) over HTTPS. No VPN 
 | `https://68lookout.dglc.com/admin/` | Signal K admin UI | Signal K own auth |
 | `https://68lookout.dglc.com/signalk/` | Signal K API + WebSocket | Signal K own auth |
 | `https://68lookout.dglc.com/grafana/` | Grafana | Grafana own login |
-| `https://68lookout.dglc.com/sprinkler/` | OpenSprinkler (`10.0.0.17:5000`) | none |
+| `https://68lookout.dglc.com/sprinkler/` | OpenSprinkler (`10.0.0.17:5000`) | OpenSprinkler own auth |
 
 **WilhelmSK mobile app:** host `68lookout.dglc.com`, port `443`, SSL enabled.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,7 +115,6 @@ The Arduino pressure sensors (10.0.0.114 and 10.0.0.219) are programmed from a s
 - Signal K config: `~/.signalk/settings.json`
 - Python venv: `~/pivac-venv/` (always use this)
 - nginx site config: `/etc/nginx/sites-available/pivac`
-- nginx Basic Auth credentials: `/etc/nginx/.htpasswd` (user: dglcinc)
 - TLS certificate: `/etc/letsencrypt/live/68lookout.dglc.com/` (auto-renews via certbot timer)
 - Grafana config: `/etc/grafana/grafana.ini`
 
@@ -129,12 +128,12 @@ All remote access goes through nginx on the Pi (`10.0.0.82`) over HTTPS. No VPN 
 
 | URL | Service | Auth |
 |-----|---------|------|
-| `https://68lookout.dglc.com/admin/` | Signal K admin UI | nginx Basic Auth |
+| `https://68lookout.dglc.com/admin/` | Signal K admin UI | Signal K own auth |
 | `https://68lookout.dglc.com/signalk/` | Signal K API + WebSocket | Signal K own auth |
 | `https://68lookout.dglc.com/grafana/` | Grafana | Grafana own login |
-| `https://68lookout.dglc.com/sprinkler/` | OpenSprinkler (`10.0.0.17:5000`) | nginx Basic Auth |
+| `https://68lookout.dglc.com/sprinkler/` | OpenSprinkler (`10.0.0.17:5000`) | none |
 
-**WilhelmSK mobile app:** host `68lookout.dglc.com`, port `443`, SSL enabled. Uses the `/signalk/` path which has no Basic Auth (WilhelmSK doesn't support it). **WilhelmSK Grafana widget:** use `https://68lookout.dglc.com/grafana/` — Basic Auth must be absent from this path or the app crashes.
+**WilhelmSK mobile app:** host `68lookout.dglc.com`, port `443`, SSL enabled.
 
 **Signal K behind proxy — Trust Proxy:** The `/signalk/` nginx location block passes `X-Forwarded-Proto: https` and `X-Forwarded-For`. Signal K's "Trust Proxy" setting (Server → Settings in the admin UI) must be enabled for Signal K to use these headers when constructing endpoint URLs. Without it, Signal K advertises `ws://localhost:3000/...` instead of `wss://68lookout.dglc.com/...`, breaking WilhelmSK's WebSocket connection. Verify with: `curl -s https://68lookout.dglc.com/signalk/ | python3 -m json.tool` — `signalk-ws` should show `wss://68lookout.dglc.com/signalk/v1/stream`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,16 @@
-# CLAUDE.md — pivac (project-specific)
+# CLAUDE.md
 
-> Working style, machine detection, and GitHub conventions are in the global context:
-> `<github-dir>/claude-contexts/CLAUDE.md`
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Working Style
+
+- **Execute without repeated check-ins.** Before a multi-step task, state the plan briefly and confirm once. Then carry out all steps without asking permission at each one.
+- **Targeted edits, not rewrites.** When modifying an existing file, make surgical changes to the relevant lines. Do not rewrite or reorder content that isn't changing — it creates noise in diffs and risks dropping things accidentally.
+- **PR workflow for code.** Always create a feature branch and open a pull request for code and documentation changes. Only push directly to `master` for meta/context files (CLAUDE.md).
+- **Keep CLAUDE.md current.** After significant changes — new architecture, bug fixes, new devices, deployment changes — update this file and include it in the commit.
+- **No unnecessary confirmation loops.** Don't ask "should I proceed?" or "does this look right?" mid-task. Finish the work, then summarize what was done.
+- **Commit message quality.** Write commit messages that explain why, not just what. Reference the problem being solved, not just the files changed.
+- **Prose over bullets in explanations.** When explaining an approach or decision, write in sentences rather than fragmenting everything into bullet lists.
 
 ## What This Project Does
 
@@ -109,7 +118,6 @@ The Arduino pressure sensors (10.0.0.114 and 10.0.0.219) are programmed from a s
 - nginx Basic Auth credentials: `/etc/nginx/.htpasswd` (user: dglcinc)
 - TLS certificate: `/etc/letsencrypt/live/68lookout.dglc.com/` (auto-renews via certbot timer)
 - Grafana config: `/etc/grafana/grafana.ini`
-- WireGuard keys (unused, kept for reference): `/etc/wireguard/`
 
 ## Remote Access
 
@@ -128,7 +136,7 @@ All remote access goes through nginx on the Pi (`10.0.0.82`) over HTTPS. No VPN 
 
 **WilhelmSK mobile app:** host `68lookout.dglc.com`, port `443`, SSL enabled. Uses the `/signalk/` path which has no Basic Auth (WilhelmSK doesn't support it). **WilhelmSK Grafana widget:** use `https://68lookout.dglc.com/grafana/` — Basic Auth must be absent from this path or the app crashes.
 
-**Important — Signal K behind nginx:** The `/signalk/` location block must include `proxy_set_header X-Forwarded-Proto https` and `proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for`. Without these, Signal K constructs its WebSocket discovery URL as `ws://localhost:3000/...` instead of `wss://68lookout.dglc.com/...`, causing WilhelmSK to attempt a plain WebSocket connection on port 80, which nginx redirects (301) and breaks the handshake. Signal K's "Trust Proxy" setting must also be enabled in the admin UI.
+**Signal K behind proxy — Trust Proxy:** The `/signalk/` nginx location block passes `X-Forwarded-Proto: https` and `X-Forwarded-For`. Signal K's "Trust Proxy" setting (Server → Settings in the admin UI) must be enabled for Signal K to use these headers when constructing endpoint URLs. Without it, Signal K advertises `ws://localhost:3000/...` instead of `wss://68lookout.dglc.com/...`, breaking WilhelmSK's WebSocket connection. Verify with: `curl -s https://68lookout.dglc.com/signalk/ | python3 -m json.tool` — `signalk-ws` should show `wss://68lookout.dglc.com/signalk/v1/stream`.
 
 **nginx reload after config changes:**
 ```bash

--- a/pivac/Emporia.py
+++ b/pivac/Emporia.py
@@ -54,7 +54,8 @@ def _get_device_cache(vue, config):
 
     panels = config.get('panels', {})
     devices = vue.get_devices()
-    vue.populate_device_properties(devices)
+    for device in devices:
+        vue.populate_device_properties(device)
 
     for device in devices:
         gid = device.device_gid

--- a/pivac/Emporia.py
+++ b/pivac/Emporia.py
@@ -115,7 +115,7 @@ def status(config={}, output="default"):
             deviceGids=gids,
             instant=datetime.now(timezone.utc),
             scale=Scale.MINUTE.value,
-            unit=Unit.WATTS.value
+            unit=Unit.KWH.value
         )
 
         for gid, usage_device in devices_usage.items():
@@ -134,7 +134,9 @@ def status(config={}, output="default"):
                 if channel is None or channel.usage is None:
                     continue
 
-                watts = round(channel.usage, 1)
+                # API returns kWh over the scale interval (1 minute); convert to watts.
+                # kWh/min * 60 min/hr * 1000 W/kW = W
+                watts = round(channel.usage * 60 * 1000, 1)
 
                 # Use the cached channel name from populate_device_properties; fall back
                 # to the name on the usage object, then a generic label.

--- a/pivac/Emporia.py
+++ b/pivac/Emporia.py
@@ -111,12 +111,12 @@ def status(config={}, output="default"):
         sk_base = config.get('sk_path', 'electrical.emporia')
 
         gids = list(cache.keys())
-        devices_usage, timestamp = vue.get_device_list_usage(
+        devices_usage = vue.get_device_list_usage(
             deviceGids=gids,
             instant=datetime.now(timezone.utc),
             scale=Scale.MINUTE.value,
             unit=Unit.KWH.value
-        )
+        )  # returns dict[int, VueUsageDevice] directly (no timestamp) since pyemvue API update
 
         for gid, usage_device in devices_usage.items():
             if gid not in cache:

--- a/scripts/emporia-discover.py
+++ b/scripts/emporia-discover.py
@@ -67,7 +67,8 @@ def main():
 
     print("Fetching devices...\n")
     devices = vue.get_devices()
-    vue.populate_device_properties(devices)
+    for device in devices:
+        vue.populate_device_properties(device)
 
     if not devices:
         print("No devices found on this account.")

--- a/scripts/emporia-discover.py
+++ b/scripts/emporia-discover.py
@@ -85,7 +85,7 @@ def main():
         print("  GID:            %s" % device.device_gid)
         print("  Model:          %s" % (device.model or "unknown"))
         print("  Firmware:       %s" % (device.firmware or "unknown"))
-        print("  Location:       %s" % (device.location_name or "unknown"))
+        print("  Location type:  %s" % (device.location_type or "unknown"))
         print()
 
         if device.channels:
@@ -109,7 +109,7 @@ def main():
     print("    sk_path: electrical.emporia")
     print("    panels:")
     for device in devices:
-        suggested_name = (device.location_name or device.device_name or 'panel').lower().replace(' ', '_')
+        suggested_name = (device.device_name or 'panel').lower().replace(' ', '_')
         print('        "%s": %s  # %s' % (
             device.device_gid,
             suggested_name,

--- a/scripts/emporia-discover.py
+++ b/scripts/emporia-discover.py
@@ -60,9 +60,12 @@ def main():
     print("Authenticating with Emporia API...")
     vue = pyemvue.PyEmVue()
     try:
-        vue.login(username=username, password=password)
+        ok = vue.login(username=username, password=password)
     except Exception as e:
         print("ERROR: Authentication failed: %s" % e)
+        sys.exit(1)
+    if not ok:
+        print("ERROR: Authentication failed: incorrect username or password?")
         sys.exit(1)
 
     print("Fetching devices...\n")


### PR DESCRIPTION
## Summary

Newer versions of pyemvue changed `populate_device_properties()` to accept a single `VueDevice` object rather than a list. The previous code passed the entire list, causing `AttributeError: 'list' object has no attribute 'device_gid'` on startup.

Both `pivac/Emporia.py` (`_get_device_cache`) and `scripts/emporia-discover.py` are updated to iterate the device list and call `populate_device_properties(device)` once per device.

## Test plan

- [ ] `git pull` on Pi, then `source ~/pivac-venv/bin/activate`
- [ ] `python scripts/emporia-discover.py --username david@dglc.com --password YOUR_PASSWORD` — should list both panels and circuits without error
- [ ] Copy the printed config block into `/etc/pivac/config.yml` with real GIDs
- [ ] Install and start `pivac-emporia.service`, confirm readings in Signal K / Grafana