### PR TITLE
Split Power Usage into House and Apartment panels

### DIFF
--- a/grafana/dashboards/pivacr.json
+++ b/grafana/dashboards/pivacr.json
@@ -1863,42 +1863,12 @@
                 }
               }
             ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "electrical.emporia.apartment.main.mean"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "dark-green",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "electrical.emporia.apartment.air_cond.mean"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "light-blue",
-                  "mode": "fixed"
-                }
-              }
-            ]
           }
         ]
       },
       "gridPos": {
         "h": 6,
-        "w": 24,
+        "w": 12,
         "x": 0,
         "y": 32
       },
@@ -1954,8 +1924,126 @@
               }
             ]
           ],
-          "tags": []
+          "tags": [],
+          "hide": false
+        }
+      ],
+      "title": "House Power",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "default": true,
+        "type": "influxdb",
+        "uid": "bdxaqnfllu5fkf"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "watt"
         },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "electrical.emporia.apartment.main.mean"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "electrical.emporia.apartment.air_cond.mean"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "light-blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 32
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
         {
           "datasource": {
             "type": "influxdb",
@@ -1978,7 +2066,7 @@
           "measurement": "electrical.emporia.apartment.main",
           "orderByTime": "ASC",
           "policy": "default",
-          "refId": "B",
+          "refId": "A",
           "resultFormat": "time_series",
           "select": [
             [
@@ -2019,7 +2107,7 @@
           "measurement": "electrical.emporia.apartment.air_cond",
           "orderByTime": "ASC",
           "policy": "default",
-          "refId": "C",
+          "refId": "B",
           "resultFormat": "time_series",
           "select": [
             [
@@ -2039,7 +2127,7 @@
           "hide": false
         }
       ],
-      "title": "Power Usage",
+      "title": "Apartment Power",
       "type": "timeseries"
     }
   ],


### PR DESCRIPTION
## Summary
- Replaces the single "Power Usage" panel with two side-by-side panels: **House Power** (left) and **Apartment Power** (right)
- Each panel auto-scales its Y axis independently, so apartment circuits are no longer compressed by the house's larger wattage range
- House panel: `electrical.emporia.house.main`
- Apartment panel: `electrical.emporia.apartment.main` + `electrical.emporia.apartment.air_cond`

## Test plan
- [ ] Merge and `git pull` on Pi — Grafana picks up the new panels within 30 seconds
- [ ] Verify House Power shows house.main with dark-blue color
- [ ] Verify Apartment Power shows apartment.main (dark-green) and air_cond (light-blue) at readable scale

🤖 Generated with [Claude Code](https://claude.com/claude-code)