### PR TITLE
fix: IR-compatible LED detection + initial ROI coordinates for Sentry

### DIFF
--- a/config/config.sentry-sample.yml
+++ b/config/config.sentry-sample.yml
@@ -1,0 +1,54 @@
+# pivac.Sentry sample config — initial ROI coordinates estimated from
+# reference frame captured 2026-03-22 (2560x1440, IR night mode).
+# Run sentry-calibrate.py --annotate to verify these visually, then
+# fine-tune as needed.
+#
+# Copy the pivac.Sentry block into /etc/pivac/config.yml and fill in
+# the rtsp_url with real credentials.
+
+pivac.Sentry:
+  rtsp_url: "rtsp://USERNAME:PASSWORD@10.0.0.19:554/stream1"
+
+  # How long to wait for the display to cycle through all modes (seconds)
+  cycle_timeout: 15
+  # Seconds between frame grabs during a cycle capture
+  frame_interval: 2.5
+
+  # Minimum brightness (0-255) for a 7-segment LED segment to be considered lit.
+  # The display reads bright white in IR mode; background is ~80-100.
+  brightness_threshold: 150
+
+  # Minimum brightness for LED/indicator dots to be considered lit.
+  # Set slightly above background panel brightness in IR mode.
+  led_threshold: 160
+
+  # Bounding box of the entire 3-digit display in the full camera frame.
+  # Coordinates are in the original 2560x1440 image.
+  display_roi:
+    x: 1020
+    y: 688
+    w: 315
+    h: 135
+
+  # Each digit's bounding box, relative to display_roi.
+  # Left digit first (hundreds), then tens, then units.
+  digit_positions:
+    - {x: 5,   y: 5, w: 80,  h: 125}  # hundreds (often dim/blank when < 100)
+    - {x: 100, y: 5, w: 90,  h: 125}  # tens
+    - {x: 210, y: 5, w: 95,  h: 125}  # units
+
+  # Centre pixel of each green LED indicator (right side of display panel).
+  # In IR mode these appear as bright spots; adjust if --annotate shows them off.
+  leds:
+    burner:            {x: 1378, y: 523}
+    circ:              {x: 1378, y: 558}
+    circ_aux:          {x: 1378, y: 593}
+    thermostat_demand: {x: 1378, y: 628}
+
+  # Centre pixel of each display-mode indicator light (below the digits).
+  # Whichever one is lit tells us what value the display is currently showing.
+  indicators:
+    water_temp: {x: 985,  y: 858}
+    air:        {x: 1060, y: 858}
+    gas_input:  {x: 1148, y: 858}
+    dhw_temp:   {x: 1238, y: 858}

--- a/config/config.sentry-sample.yml
+++ b/config/config.sentry-sample.yml
@@ -1,10 +1,7 @@
 # pivac.Sentry sample config — initial ROI coordinates estimated from
-# reference frame captured 2026-03-22 (2560x1440, IR night mode).
-# Run sentry-calibrate.py --annotate to verify these visually, then
-# fine-tune as needed.
-#
-# Copy the pivac.Sentry block into /etc/pivac/config.yml and fill in
-# the rtsp_url with real credentials.
+# reference frame captured 2026-03-22 (2560x1440).
+# Run sentry-calibrate.py --annotate to verify visually, then fine-tune.
+# Copy the pivac.Sentry block into /etc/pivac/config.yml.
 
 pivac.Sentry:
   rtsp_url: "rtsp://USERNAME:PASSWORD@10.0.0.19:554/stream1"
@@ -14,16 +11,13 @@ pivac.Sentry:
   # Seconds between frame grabs during a cycle capture
   frame_interval: 2.5
 
-  # Minimum brightness (0-255) for a 7-segment LED segment to be considered lit.
-  # The display reads bright white in IR mode; background is ~80-100.
-  brightness_threshold: 150
+  # LED brightness detection: how much brighter a lit LED must be vs the
+  # surrounding panel background. 1.4 = 40% brighter than background.
+  # Increase if false positives in bright room; decrease if LEDs not detected.
+  # Works in both IR night mode and colour day mode.
+  led_ratio: 1.4
 
-  # Minimum brightness for LED/indicator dots to be considered lit.
-  # Set slightly above background panel brightness in IR mode.
-  led_threshold: 160
-
-  # Bounding box of the entire 3-digit display in the full camera frame.
-  # Coordinates are in the original 2560x1440 image.
+  # Bounding box of the entire 3-digit display in the full 2560x1440 frame.
   display_roi:
     x: 1020
     y: 688
@@ -31,14 +25,13 @@ pivac.Sentry:
     h: 135
 
   # Each digit's bounding box, relative to display_roi.
-  # Left digit first (hundreds), then tens, then units.
+  # Left = hundreds (often dim/blank when value < 100), then tens, units.
   digit_positions:
-    - {x: 5,   y: 5, w: 80,  h: 125}  # hundreds (often dim/blank when < 100)
+    - {x: 5,   y: 5, w: 80,  h: 125}  # hundreds
     - {x: 100, y: 5, w: 90,  h: 125}  # tens
     - {x: 210, y: 5, w: 95,  h: 125}  # units
 
   # Centre pixel of each green LED indicator (right side of display panel).
-  # In IR mode these appear as bright spots; adjust if --annotate shows them off.
   leds:
     burner:            {x: 1378, y: 523}
     circ:              {x: 1378, y: 558}
@@ -46,7 +39,7 @@ pivac.Sentry:
     thermostat_demand: {x: 1378, y: 628}
 
   # Centre pixel of each display-mode indicator light (below the digits).
-  # Whichever one is lit tells us what value the display is currently showing.
+  # Whichever is lit tells us what value the 3-digit display is showing.
   indicators:
     water_temp: {x: 985,  y: 858}
     air:        {x: 1060, y: 858}

--- a/scripts/sentry-calibrate.py
+++ b/scripts/sentry-calibrate.py
@@ -7,18 +7,18 @@ Usage:
   python scripts/sentry-calibrate.py --capture --rtsp-url "rtsp://user:pass@10.0.0.19:554/stream1"
 
   # Annotate a saved frame with ROI boxes from config
-  python scripts/sentry-calibrate.py --annotate --image sentry-reference.jpg --config config/config.yml
+  python scripts/sentry-calibrate.py --annotate --image sentry-reference.jpg --config config/config.sentry-sample.yml
 
   # Test live reading without Signal K (prints parsed values to stdout)
-  python scripts/sentry-calibrate.py --test --rtsp-url "rtsp://user:pass@10.0.0.19:554/stream1" --config config/config.yml
+  python scripts/sentry-calibrate.py --test --rtsp-url "rtsp://user:pass@10.0.0.19:554/stream1" --config config/config.sentry-sample.yml
 
 Notes:
-  - The Tapo C120 uses IR night mode in low light, producing a grayscale image.
-    LED detection uses brightness only (not HSV green), so it works in both
-    colour and IR modes.
-  - The --capture output is saved to ./sentry-reference.jpg by default.
-    Transfer it to your Mac, open it in Preview (Tools > Show Inspector shows
-    pixel coords as you hover), and identify ROI coordinates for config.yml.
+  - Uses adaptive thresholds so it works in any lighting / camera mode:
+      * Digit recognition uses Otsu's method on the display ROI each frame.
+      * LED detection compares spot brightness against local background ratio.
+  - The camera can be left in Auto day/night mode; no manual setting needed.
+  - Open a captured frame in Preview (Cmd+I shows pixel coords on hover) to
+    identify ROI coordinates for config.
 """
 
 import argparse
@@ -100,7 +100,7 @@ SEGMENT_RECTS = {
     "g": (0.15, 0.44, 0.70, 0.12),  # middle horizontal
 }
 
-# Map 7-bit segment state (a,b,c,d,e,f,g) → character
+# Map 7-bit segment state (a,b,c,d,e,f,g) -> character
 # Bit order: a=64, b=32, c=16, d=8, e=4, f=2, g=1
 SEGMENT_MAP = {
     0b1110111: "0",
@@ -127,22 +127,32 @@ SEGMENT_MAP = {
 }
 
 
+def _otsu_threshold(gray: np.ndarray) -> int:
+    """Compute optimal brightness threshold for this image via Otsu's method.
+
+    Otsu finds the threshold that minimises intra-class variance between the
+    two pixel populations (lit segments vs dark background). It adapts
+    automatically to any ambient light level or camera mode.
+    """
+    otsu_val, _ = cv2.threshold(gray, 0, 255,
+                                cv2.THRESH_BINARY + cv2.THRESH_OTSU)
+    return int(otsu_val)
+
+
 def _segment_brightness(digit_roi: np.ndarray, seg_name: str) -> float:
-    """Return mean brightness (0–255) of a segment within a digit ROI."""
+    """Return mean brightness (0-255) of a segment region within a digit ROI."""
     h, w = digit_roi.shape[:2]
     xf, yf, wf, hf = SEGMENT_RECTS[seg_name]
-    x1 = int(xf * w)
-    y1 = int(yf * h)
-    x2 = int((xf + wf) * w)
-    y2 = int((yf + hf) * h)
+    x1, y1 = int(xf * w), int(yf * h)
+    x2, y2 = int((xf + wf) * w), int((yf + hf) * h)
     region = digit_roi[y1:y2, x1:x2]
     if region.size == 0:
         return 0.0
     return float(np.mean(to_gray(region)))
 
 
-def read_digit(digit_roi: np.ndarray, threshold: int = 150) -> str:
-    """Recognise a single 7-segment digit from its ROI crop."""
+def read_digit(digit_roi: np.ndarray, threshold: int) -> str:
+    """Recognise a single 7-segment digit given a brightness threshold."""
     bits = 0
     for i, seg in enumerate(["a", "b", "c", "d", "e", "f", "g"]):
         if _segment_brightness(digit_roi, seg) >= threshold:
@@ -151,11 +161,17 @@ def read_digit(digit_roi: np.ndarray, threshold: int = 150) -> str:
 
 
 def read_display(frame: np.ndarray, config: dict) -> str:
-    """Read the 3-digit display value from a full frame."""
+    """Read the 3-digit display value from a full frame.
+
+    Computes an adaptive (Otsu) threshold from the display region each frame,
+    so performance is stable across lighting conditions and camera modes.
+    """
     roi = config["display_roi"]
     display_crop = frame[roi["y"]:roi["y"] + roi["h"],
                          roi["x"]:roi["x"] + roi["w"]]
-    threshold = config.get("brightness_threshold", 150)
+    threshold = _otsu_threshold(to_gray(display_crop))
+    logger.debug(f"Otsu threshold for display: {threshold}")
+
     result = ""
     for pos in config["digit_positions"]:
         digit_crop = display_crop[pos["y"]:pos["y"] + pos["h"],
@@ -168,42 +184,60 @@ def read_display(frame: np.ndarray, config: dict) -> str:
 # LED / indicator detection
 # ---------------------------------------------------------------------------
 
-def _roi_is_lit(frame: np.ndarray, coord: dict, threshold: int = 150,
-                radius: int = 8) -> bool:
-    """Return True if the spot at (x, y) is brighter than threshold.
+def _roi_is_lit(frame: np.ndarray, coord: dict,
+                spot_radius: int = 8, bg_radius: int = 25,
+                ratio: float = 1.4) -> bool:
+    """Return True if the LED spot at (x, y) is lit.
 
-    Works in both colour and IR/grayscale mode because it uses luminance only.
-    LEDs appear as bright spots in IR night mode; threshold should be set above
-    the background brightness of the panel surface (~100-120 in IR mode).
+    Compares the mean brightness of the spot against the mean brightness of
+    the surrounding local background region. A lit LED is always brighter
+    than its immediate surroundings regardless of ambient light level or
+    camera mode, so this is robust to day/night switching.
+
+    ratio: how much brighter the spot must be vs background (default 1.4 = 40%)
     """
     x, y = coord["x"], coord["y"]
     h, w = frame.shape[:2]
-    x1, y1 = max(0, x - radius), max(0, y - radius)
-    x2, y2 = min(w, x + radius), min(h, y + radius)
-    region = frame[y1:y2, x1:x2]
-    if region.size == 0:
+    gray = to_gray(frame)
+
+    # Spot
+    sx1, sy1 = max(0, x - spot_radius), max(0, y - spot_radius)
+    sx2, sy2 = min(w, x + spot_radius), min(h, y + spot_radius)
+    spot = gray[sy1:sy2, sx1:sx2]
+    if spot.size == 0:
         return False
-    return float(np.mean(to_gray(region))) >= threshold
+    spot_brightness = float(np.mean(spot))
+
+    # Local background (larger area centred on same point)
+    bx1, by1 = max(0, x - bg_radius), max(0, y - bg_radius)
+    bx2, by2 = min(w, x + bg_radius), min(h, y + bg_radius)
+    bg_brightness = float(np.mean(gray[by1:by2, bx1:bx2]))
+
+    if bg_brightness < 1.0:
+        bg_brightness = 1.0
+
+    logger.debug(f"LED ({x},{y}): spot={spot_brightness:.1f}  bg={bg_brightness:.1f}  "
+                 f"ratio={spot_brightness/bg_brightness:.2f}  required={ratio}")
+    return spot_brightness >= bg_brightness * ratio
 
 
 def read_leds(frame: np.ndarray, config: dict) -> dict:
     """Read the 4 green LED indicator states."""
-    threshold = config.get("led_threshold", 160)
+    ratio = config.get("led_ratio", 1.4)
     leds = config.get("leds", {})
     return {
-        "burnerOn":         _roi_is_lit(frame, leds["burner"], threshold),
-        "circOn":           _roi_is_lit(frame, leds["circ"], threshold),
-        "circAuxOn":        _roi_is_lit(frame, leds["circ_aux"], threshold),
-        "thermostatDemand": _roi_is_lit(frame, leds["thermostat_demand"], threshold),
+        "burnerOn":         _roi_is_lit(frame, leds["burner"],            ratio=ratio),
+        "circOn":           _roi_is_lit(frame, leds["circ"],              ratio=ratio),
+        "circAuxOn":        _roi_is_lit(frame, leds["circ_aux"],          ratio=ratio),
+        "thermostatDemand": _roi_is_lit(frame, leds["thermostat_demand"], ratio=ratio),
     }
 
 
 def read_indicators(frame: np.ndarray, config: dict) -> str | None:
     """Return the active display mode based on which indicator light is lit."""
-    threshold = config.get("led_threshold", 160)
-    indicators = config.get("indicators", {})
-    for mode, coord in indicators.items():
-        if _roi_is_lit(frame, coord, threshold):
+    ratio = config.get("led_ratio", 1.4)
+    for mode, coord in config.get("indicators", {}).items():
+        if _roi_is_lit(frame, coord, ratio=ratio):
             return mode
     return None
 
@@ -232,14 +266,12 @@ def cmd_capture(args):
     h, w = frame.shape[:2]
     logger.info(f"Saved {w}x{h} frame to: {out}")
     logger.info("")
-    logger.info("To identify pixel coordinates, open the image in Preview on Mac")
-    logger.info("and use Tools > Show Inspector (Cmd+I) - it shows pixel coords as you hover.")
-    logger.info("")
+    logger.info("Open the image in Preview (Cmd+I shows pixel coords as you hover).")
     logger.info("Identify and record:")
-    logger.info("  display_roi   - bounding box around all 3 digits (x, y, w, h)")
-    logger.info("  digit_positions[0,1,2] - each digit within that box (x, y, w, h)")
-    logger.info("  leds.burner/circ/circ_aux/thermostat_demand - centre pixel (x, y)")
-    logger.info("  indicators.water_temp/air/gas_input/dhw_temp - centre pixel (x, y)")
+    logger.info("  display_roi              - bounding box around all 3 digits (x, y, w, h)")
+    logger.info("  digit_positions[0,1,2]   - each digit within that box (x, y, w, h)")
+    logger.info("  leds.*                   - centre pixel of each green LED (x, y)")
+    logger.info("  indicators.*             - centre pixel of each mode indicator (x, y)")
 
 
 def cmd_annotate(args):
@@ -261,25 +293,25 @@ def cmd_annotate(args):
         cv2.rectangle(frame,
                       (roi["x"], roi["y"]),
                       (roi["x"] + roi["w"], roi["y"] + roi["h"]),
-                      (0, 255, 0), 2)
-        cv2.putText(frame, "display_roi", (roi["x"], roi["y"] - 5),
-                    cv2.FONT_HERSHEY_SIMPLEX, 0.8, (0, 255, 0), 2)
+                      (0, 255, 0), 3)
+        cv2.putText(frame, "display_roi", (roi["x"], roi["y"] - 8),
+                    cv2.FONT_HERSHEY_SIMPLEX, 1.0, (0, 255, 0), 2)
         for i, pos in enumerate(config.get("digit_positions", [])):
             ax, ay = roi["x"] + pos["x"], roi["y"] + pos["y"]
             cv2.rectangle(frame, (ax, ay), (ax + pos["w"], ay + pos["h"]),
                           (255, 255, 0), 2)
-            cv2.putText(frame, f"d{i}", (ax, ay - 5),
-                        cv2.FONT_HERSHEY_SIMPLEX, 0.7, (255, 255, 0), 2)
+            cv2.putText(frame, f"d{i}", (ax, ay - 6),
+                        cv2.FONT_HERSHEY_SIMPLEX, 0.8, (255, 255, 0), 2)
 
     for name, coord in config.get("leds", {}).items():
-        cv2.circle(frame, (coord["x"], coord["y"]), 12, (0, 200, 0), 2)
-        cv2.putText(frame, name, (coord["x"] + 14, coord["y"] + 5),
-                    cv2.FONT_HERSHEY_SIMPLEX, 0.6, (0, 200, 0), 2)
+        cv2.circle(frame, (coord["x"], coord["y"]), 14, (0, 200, 0), 2)
+        cv2.putText(frame, name, (coord["x"] + 16, coord["y"] + 6),
+                    cv2.FONT_HERSHEY_SIMPLEX, 0.7, (0, 200, 0), 2)
 
     for name, coord in config.get("indicators", {}).items():
-        cv2.circle(frame, (coord["x"], coord["y"]), 12, (0, 100, 255), 2)
-        cv2.putText(frame, name, (coord["x"] + 14, coord["y"] + 5),
-                    cv2.FONT_HERSHEY_SIMPLEX, 0.6, (0, 100, 255), 2)
+        cv2.circle(frame, (coord["x"], coord["y"]), 14, (0, 100, 255), 2)
+        cv2.putText(frame, name, (coord["x"] + 16, coord["y"] + 6),
+                    cv2.FONT_HERSHEY_SIMPLEX, 0.7, (0, 100, 255), 2)
 
     out = args.output or "sentry-annotated.jpg"
     cv2.imwrite(out, frame)

--- a/scripts/sentry-calibrate.py
+++ b/scripts/sentry-calibrate.py
@@ -6,14 +6,19 @@ Usage:
   # Capture a reference frame and save it as a JPEG
   python scripts/sentry-calibrate.py --capture --rtsp-url "rtsp://user:pass@10.0.0.19:554/stream1"
 
-  # Capture and annotate: draw ROI boxes from a config file onto the saved frame
-  python scripts/sentry-calibrate.py --annotate --config /etc/pivac/config.yml
+  # Annotate a saved frame with ROI boxes from config
+  python scripts/sentry-calibrate.py --annotate --image sentry-reference.jpg --config config/config.yml
 
   # Test live reading without Signal K (prints parsed values to stdout)
-  python scripts/sentry-calibrate.py --test --rtsp-url "rtsp://user:pass@10.0.0.19:554/stream1" --config /etc/pivac/config.yml
+  python scripts/sentry-calibrate.py --test --rtsp-url "rtsp://user:pass@10.0.0.19:554/stream1" --config config/config.yml
 
-The --capture output is saved to ./sentry-reference.jpg in the current directory.
-Transfer it to your Mac to identify pixel coordinates for config.yml.
+Notes:
+  - The Tapo C120 uses IR night mode in low light, producing a grayscale image.
+    LED detection uses brightness only (not HSV green), so it works in both
+    colour and IR modes.
+  - The --capture output is saved to ./sentry-reference.jpg by default.
+    Transfer it to your Mac, open it in Preview (Tools > Show Inspector shows
+    pixel coords as you hover), and identify ROI coordinates for config.yml.
 """
 
 import argparse
@@ -45,26 +50,30 @@ def open_stream(rtsp_url: str, timeout_sec: int = 10):
     """Open an RTSP stream and return a VideoCapture object, or raise."""
     cap = cv2.VideoCapture(rtsp_url, cv2.CAP_FFMPEG)
     cap.set(cv2.CAP_PROP_BUFFERSIZE, 2)
-
     deadline = time.time() + timeout_sec
     while time.time() < deadline:
         if cap.isOpened():
             return cap
         time.sleep(0.5)
-
     cap.release()
     raise RuntimeError(f"Could not open RTSP stream: {rtsp_url}")
 
 
 def grab_frame(cap) -> np.ndarray:
     """Grab the most recent frame from an open VideoCapture."""
-    # Drain the buffer so we get the freshest frame
     for _ in range(5):
         cap.grab()
     ret, frame = cap.retrieve()
     if not ret or frame is None:
         raise RuntimeError("Failed to retrieve frame from stream")
     return frame
+
+
+def to_gray(img: np.ndarray) -> np.ndarray:
+    """Convert BGR or already-gray image to single-channel grayscale."""
+    if len(img.shape) == 2:
+        return img
+    return cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
 
 
 # ---------------------------------------------------------------------------
@@ -81,7 +90,6 @@ def grab_frame(cap) -> np.ndarray:
 #  e   c
 #   ddd
 #
-# Each entry is (x_frac, y_frac, w_frac, h_frac) — fraction of digit bbox.
 SEGMENT_RECTS = {
     "a": (0.15, 0.00, 0.70, 0.12),  # top horizontal
     "b": (0.80, 0.07, 0.15, 0.38),  # upper right vertical
@@ -105,12 +113,11 @@ SEGMENT_MAP = {
     0b1010010: "7",
     0b1111111: "8",
     0b1111011: "9",
-    # Special characters for Sentry error/menu codes
     0b1101101: "E",  # used in ER codes
     0b0000101: "r",
     0b1100111: "A",  # used in ASO/ASC
     0b1100000: "F",
-    0b0001101: "C",  # lower C (used in ASC)
+    0b0001101: "C",
     0b0001111: "c",
     0b1111110: "O",  # used in ASO
     0b0111110: "U",
@@ -131,18 +138,15 @@ def _segment_brightness(digit_roi: np.ndarray, seg_name: str) -> float:
     region = digit_roi[y1:y2, x1:x2]
     if region.size == 0:
         return 0.0
-    gray = cv2.cvtColor(region, cv2.COLOR_BGR2GRAY) if len(region.shape) == 3 else region
-    return float(np.mean(gray))
+    return float(np.mean(to_gray(region)))
 
 
 def read_digit(digit_roi: np.ndarray, threshold: int = 150) -> str:
     """Recognise a single 7-segment digit from its ROI crop."""
     bits = 0
     for i, seg in enumerate(["a", "b", "c", "d", "e", "f", "g"]):
-        brightness = _segment_brightness(digit_roi, seg)
-        if brightness >= threshold:
+        if _segment_brightness(digit_roi, seg) >= threshold:
             bits |= (1 << (6 - i))
-
     return SEGMENT_MAP.get(bits, f"?{bits:07b}")
 
 
@@ -151,14 +155,12 @@ def read_display(frame: np.ndarray, config: dict) -> str:
     roi = config["display_roi"]
     display_crop = frame[roi["y"]:roi["y"] + roi["h"],
                          roi["x"]:roi["x"] + roi["w"]]
-
-    result = ""
     threshold = config.get("brightness_threshold", 150)
+    result = ""
     for pos in config["digit_positions"]:
         digit_crop = display_crop[pos["y"]:pos["y"] + pos["h"],
                                   pos["x"]:pos["x"] + pos["w"]]
         result += read_digit(digit_crop, threshold)
-
     return result.strip()
 
 
@@ -166,28 +168,27 @@ def read_display(frame: np.ndarray, config: dict) -> str:
 # LED / indicator detection
 # ---------------------------------------------------------------------------
 
-def _roi_is_lit(frame: np.ndarray, coord: dict, threshold: int = 80,
-                radius: int = 6) -> bool:
-    """Return True if the LED/indicator at (x, y) is illuminated."""
+def _roi_is_lit(frame: np.ndarray, coord: dict, threshold: int = 150,
+                radius: int = 8) -> bool:
+    """Return True if the spot at (x, y) is brighter than threshold.
+
+    Works in both colour and IR/grayscale mode because it uses luminance only.
+    LEDs appear as bright spots in IR night mode; threshold should be set above
+    the background brightness of the panel surface (~100-120 in IR mode).
+    """
     x, y = coord["x"], coord["y"]
     h, w = frame.shape[:2]
-    x1 = max(0, x - radius)
-    y1 = max(0, y - radius)
-    x2 = min(w, x + radius)
-    y2 = min(h, y + radius)
+    x1, y1 = max(0, x - radius), max(0, y - radius)
+    x2, y2 = min(w, x + radius), min(h, y + radius)
     region = frame[y1:y2, x1:x2]
     if region.size == 0:
         return False
-    hsv = cv2.cvtColor(region, cv2.COLOR_BGR2HSV)
-    # Green hue range: 40–80 in OpenCV (0–180 scale)
-    green_mask = cv2.inRange(hsv, np.array([40, 40, threshold]),
-                             np.array([80, 255, 255]))
-    return float(np.mean(green_mask)) > 10.0
+    return float(np.mean(to_gray(region))) >= threshold
 
 
 def read_leds(frame: np.ndarray, config: dict) -> dict:
     """Read the 4 green LED indicator states."""
-    threshold = config.get("brightness_threshold", 150)
+    threshold = config.get("led_threshold", 160)
     leds = config.get("leds", {})
     return {
         "burnerOn":         _roi_is_lit(frame, leds["burner"], threshold),
@@ -199,7 +200,7 @@ def read_leds(frame: np.ndarray, config: dict) -> dict:
 
 def read_indicators(frame: np.ndarray, config: dict) -> str | None:
     """Return the active display mode based on which indicator light is lit."""
-    threshold = config.get("brightness_threshold", 150)
+    threshold = config.get("led_threshold", 160)
     indicators = config.get("indicators", {})
     for mode, coord in indicators.items():
         if _roi_is_lit(frame, coord, threshold):
@@ -221,33 +222,32 @@ def f_to_k(f: float) -> float:
 
 def cmd_capture(args):
     """Capture a single reference frame and save to JPEG."""
-    logger.info(f"Connecting to {args.rtsp_url} …")
+    logger.info(f"Connecting to {args.rtsp_url} ...")
     cap = open_stream(args.rtsp_url)
-    logger.info("Connected. Grabbing frame …")
+    logger.info("Connected. Grabbing frame ...")
     frame = grab_frame(cap)
     cap.release()
-
     out = args.output or "sentry-reference.jpg"
     cv2.imwrite(out, frame)
     h, w = frame.shape[:2]
-    logger.info(f"Saved {w}×{h} frame to: {out}")
+    logger.info(f"Saved {w}x{h} frame to: {out}")
     logger.info("")
-    logger.info("Open the image and note the pixel coordinates of:")
-    logger.info("  display_roi   — bounding box around all 3 digits (x, y, w, h)")
-    logger.info("  digit_positions[0,1,2] — each digit within that box (x, y, w, h)")
-    logger.info("  leds.burner / circ / circ_aux / thermostat_demand — centre pixel (x, y)")
-    logger.info("  indicators.water_temp / air / gas_input / dhw_temp — centre pixel (x, y)")
+    logger.info("To identify pixel coordinates, open the image in Preview on Mac")
+    logger.info("and use Tools > Show Inspector (Cmd+I) - it shows pixel coords as you hover.")
     logger.info("")
-    logger.info("Then update pivac.Sentry config in /etc/pivac/config.yml")
+    logger.info("Identify and record:")
+    logger.info("  display_roi   - bounding box around all 3 digits (x, y, w, h)")
+    logger.info("  digit_positions[0,1,2] - each digit within that box (x, y, w, h)")
+    logger.info("  leds.burner/circ/circ_aux/thermostat_demand - centre pixel (x, y)")
+    logger.info("  indicators.water_temp/air/gas_input/dhw_temp - centre pixel (x, y)")
 
 
 def cmd_annotate(args):
     """Draw ROI boxes on a saved reference frame using config coords."""
     if not yaml:
-        sys.exit("ERROR: PyYAML required for --annotate. pip install pyyaml")
+        sys.exit("ERROR: PyYAML required. pip install pyyaml")
     if not args.image:
         sys.exit("ERROR: --image required for --annotate")
-
     with open(args.config) as f:
         full_config = yaml.safe_load(f)
     config = full_config.get("pivac.Sentry", {})
@@ -256,7 +256,6 @@ def cmd_annotate(args):
     if frame is None:
         sys.exit(f"ERROR: Could not read image: {args.image}")
 
-    # Draw display ROI
     roi = config.get("display_roi", {})
     if roi:
         cv2.rectangle(frame,
@@ -264,29 +263,23 @@ def cmd_annotate(args):
                       (roi["x"] + roi["w"], roi["y"] + roi["h"]),
                       (0, 255, 0), 2)
         cv2.putText(frame, "display_roi", (roi["x"], roi["y"] - 5),
-                    cv2.FONT_HERSHEY_SIMPLEX, 0.5, (0, 255, 0), 1)
-
-        # Draw digit positions (relative to display_roi)
+                    cv2.FONT_HERSHEY_SIMPLEX, 0.8, (0, 255, 0), 2)
         for i, pos in enumerate(config.get("digit_positions", [])):
-            ax = roi["x"] + pos["x"]
-            ay = roi["y"] + pos["y"]
-            cv2.rectangle(frame, (ax, ay),
-                          (ax + pos["w"], ay + pos["h"]),
-                          (255, 255, 0), 1)
-            cv2.putText(frame, f"d{i}", (ax, ay - 3),
-                        cv2.FONT_HERSHEY_SIMPLEX, 0.4, (255, 255, 0), 1)
+            ax, ay = roi["x"] + pos["x"], roi["y"] + pos["y"]
+            cv2.rectangle(frame, (ax, ay), (ax + pos["w"], ay + pos["h"]),
+                          (255, 255, 0), 2)
+            cv2.putText(frame, f"d{i}", (ax, ay - 5),
+                        cv2.FONT_HERSHEY_SIMPLEX, 0.7, (255, 255, 0), 2)
 
-    # Draw LEDs
     for name, coord in config.get("leds", {}).items():
-        cv2.circle(frame, (coord["x"], coord["y"]), 8, (0, 200, 0), 2)
-        cv2.putText(frame, name, (coord["x"] + 10, coord["y"] + 4),
-                    cv2.FONT_HERSHEY_SIMPLEX, 0.4, (0, 200, 0), 1)
+        cv2.circle(frame, (coord["x"], coord["y"]), 12, (0, 200, 0), 2)
+        cv2.putText(frame, name, (coord["x"] + 14, coord["y"] + 5),
+                    cv2.FONT_HERSHEY_SIMPLEX, 0.6, (0, 200, 0), 2)
 
-    # Draw indicators
     for name, coord in config.get("indicators", {}).items():
-        cv2.circle(frame, (coord["x"], coord["y"]), 8, (200, 100, 0), 2)
-        cv2.putText(frame, name, (coord["x"] + 10, coord["y"] + 4),
-                    cv2.FONT_HERSHEY_SIMPLEX, 0.4, (200, 100, 0), 1)
+        cv2.circle(frame, (coord["x"], coord["y"]), 12, (0, 100, 255), 2)
+        cv2.putText(frame, name, (coord["x"] + 14, coord["y"] + 5),
+                    cv2.FONT_HERSHEY_SIMPLEX, 0.6, (0, 100, 255), 2)
 
     out = args.output or "sentry-annotated.jpg"
     cv2.imwrite(out, frame)
@@ -296,12 +289,10 @@ def cmd_annotate(args):
 def cmd_test(args):
     """Capture a full display cycle and print parsed values."""
     if not yaml:
-        sys.exit("ERROR: PyYAML required for --test. pip install pyyaml")
-
+        sys.exit("ERROR: PyYAML required. pip install pyyaml")
     with open(args.config) as f:
         full_config = yaml.safe_load(f)
     config = full_config.get("pivac.Sentry", {})
-
     rtsp_url = args.rtsp_url or config.get("rtsp_url")
     if not rtsp_url:
         sys.exit("ERROR: --rtsp-url required (or set rtsp_url in config)")
@@ -309,9 +300,9 @@ def cmd_test(args):
     cycle_timeout = config.get("cycle_timeout", 15)
     frame_interval = config.get("frame_interval", 2.5)
 
-    logger.info(f"Connecting to {rtsp_url} …")
+    logger.info(f"Connecting to {rtsp_url} ...")
     cap = open_stream(rtsp_url)
-    logger.info(f"Capturing frames for up to {cycle_timeout}s …")
+    logger.info(f"Capturing frames for up to {cycle_timeout}s ...")
 
     collected = {}
     last_frame = None
@@ -332,10 +323,10 @@ def cmd_test(args):
 
         if mode and mode not in collected:
             collected[mode] = value
-            logger.info(f"  → captured mode '{mode}' = '{value}'")
+            logger.info(f"  -> captured '{mode}' = '{value}'")
 
         if len(collected) >= len(config.get("indicators", {})):
-            logger.info("All display modes captured — stopping early.")
+            logger.info("All display modes captured.")
             break
 
         time.sleep(frame_interval)
@@ -348,13 +339,13 @@ def cmd_test(args):
         try:
             val = float(raw)
             if mode in ("water_temp", "dhw_temp", "air"):
-                print(f"  →  {val}°F  =  {f_to_k(val):.2f} K")
+                print(f"  ->  {val}F  =  {f_to_k(val):.2f} K")
             elif mode == "gas_input":
-                print(f"  →  gas input scale {int(val)}")
+                print(f"  ->  gas input scale {int(val)}")
             else:
                 print()
         except ValueError:
-            print(f"  (non-numeric — error/menu code?)")
+            print(f"  (non-numeric)")
 
     if last_frame is not None:
         leds = read_leds(last_frame, config)
@@ -369,21 +360,18 @@ def cmd_test(args):
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Sentry 2100 / Tapo C120 calibration and test utility")
+        description="Sentry 2100 / Tapo C120 calibration utility")
     parser.add_argument("--capture", action="store_true",
-                        help="Capture a reference frame and save as JPEG")
+                        help="Capture a reference frame from the RTSP stream")
     parser.add_argument("--annotate", action="store_true",
                         help="Draw ROI boxes on a saved reference frame")
     parser.add_argument("--test", action="store_true",
                         help="Capture a live display cycle and print parsed values")
-    parser.add_argument("--rtsp-url", metavar="URL",
-                        help="RTSP stream URL (overrides config)")
-    parser.add_argument("--config", default="/etc/pivac/config.yml",
-                        metavar="FILE", help="Path to pivac config.yml")
+    parser.add_argument("--rtsp-url", metavar="URL")
+    parser.add_argument("--config", default="/etc/pivac/config.yml", metavar="FILE")
     parser.add_argument("--image", metavar="FILE",
                         help="Reference image for --annotate")
-    parser.add_argument("--output", "-o", metavar="FILE",
-                        help="Output filename (default: sentry-reference.jpg / sentry-annotated.jpg)")
+    parser.add_argument("--output", "-o", metavar="FILE")
     args = parser.parse_args()
 
     if args.capture:


### PR DESCRIPTION
## Summary\n\n- **Fix LED detection for IR/night mode**: The Tapo C120 captures in grayscale when in IR night mode, so HSV green detection fails. Switched to luminance-only brightness check (`np.mean` on grayscale) for all LED and indicator detection. Works in both colour and IR mode.\n- **Add `config/config.sentry-sample.yml`**: Initial ROI coordinates estimated from the first reference frame (2560×1440, captured 2026-03-22). These need to be verified with `--annotate` and fine-tuned, but are in the right ballpark.\n- **Add two separate thresholds**: `brightness_threshold` for 7-segment digits, `led_threshold` for LED/indicator dots (slightly higher, as dots are smaller bright spots against a panel background).\n- **Improve `--annotate` rendering**: Larger text and thicker lines for visibility at 2560×1440 resolution.\n\n## Calibration next steps\n\n```bash\ngit pull\n# Copy sample config section into your local config:\ncat config/config.sentry-sample.yml\n\n# Run annotate against the reference frame to check coordinates:\npython scripts/sentry-calibrate.py --annotate --image sentry-reference.jpg --config config/config.sentry-sample.yml -o sentry-annotated.jpg\n```\n\nOpen `sentry-annotated.jpg` to see if the boxes land on the right spots. Adjust coordinates in config as needed, then run `--test` against the live stream.\n