### PR TITLE
fix: sentry digit threshold 0.35→0.50, fix zero segment map

### DIFF
--- a/config/config.sentry-sample.yml
+++ b/config/config.sentry-sample.yml
@@ -14,6 +14,12 @@ pivac.Sentry:
   # panel background. 1.4 = 40% brighter. Works in IR and colour modes.
   led_ratio: 1.4
 
+  # Digit threshold factor: threshold = mean + factor*(max-mean) per digit crop.
+  # Higher values reduce false positives on blank/dim digit positions.
+  # Raise toward 0.60 if blank digits are misread; lower toward 0.40 if
+  # dim lit digits are missed. Default 0.50 works well for IR night mode.
+  digit_threshold_factor: 0.50
+
   # Perspective warp: 4 corners of the LED glass in the original 2560x1440 frame.
   # Order: TL -> TR -> BR -> BL
   # Digit positions below are relative to the de-skewed rectified display.

--- a/scripts/sentry-calibrate.py
+++ b/scripts/sentry-calibrate.py
@@ -22,7 +22,8 @@ Usage:
 
 Notes:
   - --calibrate requires matplotlib: pip install matplotlib --break-system-packages
-  - Digit recognition: p90 per-segment brightness, threshold = mean+35%*(max-mean).
+  - Digit recognition: p90 per-segment brightness, threshold = mean + factor*(max-mean).
+    factor defaults to 0.50; tune via digit_threshold_factor in config.
   - LED/indicator detection: spot-vs-background brightness ratio.
   - Camera can stay in Auto day/night mode.
 """
@@ -114,7 +115,7 @@ SEGMENT_RECTS = {
 }
 
 SEGMENT_MAP = {
-    0b1110111: "0",
+    0b1111110: "0",
     0b0010010: "1",
     0b1011101: "2",
     0b1011011: "3",
@@ -130,7 +131,7 @@ SEGMENT_MAP = {
     0b1100000: "F",
     0b0001101: "C",
     0b0001111: "c",
-    0b1111110: "O",
+    0b1111110: "0",
     0b0111110: "U",
     0b0101111: "d",
     0b0000001: "-",
@@ -144,11 +145,17 @@ def _otsu_threshold(gray: np.ndarray) -> int:
     return int(otsu_val)
 
 
-def _digit_threshold(gray: np.ndarray) -> int:
-    """35% of the way from crop mean to crop max.  Robust for thin LED lines."""
+def _digit_threshold(gray: np.ndarray, factor: float = 0.50) -> int:
+    """Threshold = mean + factor*(max-mean).
+
+    Higher factor reduces false positives on dim/blank digit positions where
+    ambient IR glow raises the max slightly above true background.  Default
+    0.50 works well for this display; tune via digit_threshold_factor in
+    config if needed.
+    """
     mean_val = float(np.mean(gray))
     max_val = float(np.max(gray))
-    return int(mean_val + 0.35 * (max_val - mean_val))
+    return int(mean_val + factor * (max_val - mean_val))
 
 
 def _segment_brightness(digit_roi: np.ndarray, seg_name: str) -> float:
@@ -173,12 +180,13 @@ def read_digit(digit_roi: np.ndarray, threshold: int) -> str:
 
 def read_display(frame: np.ndarray, config: dict) -> str:
     display_crop = _get_display_crop(frame, config)
+    factor = config.get("digit_threshold_factor", 0.50)
     result = ""
     for pos in config["digit_positions"]:
         digit_crop = display_crop[pos["y"]:pos["y"] + pos["h"],
                                   pos["x"]:pos["x"] + pos["w"]]
         gray = to_gray(digit_crop)
-        threshold = _digit_threshold(gray)
+        threshold = _digit_threshold(gray, factor=factor)
         result += read_digit(digit_crop, threshold)
     return result.strip()
 
@@ -615,6 +623,8 @@ def cmd_debug(args):
           f"Max: {np.max(gray_display):.1f}  "
           f"Otsu: {_otsu_threshold(gray_display)}")
 
+    factor = config.get("digit_threshold_factor", 0.50)
+    print(f"  digit_threshold_factor: {factor}")
     print("\n=== Digit crops ===")
     for i, pos in enumerate(config.get("digit_positions", [])):
         digit_crop = display_crop[pos["y"]:pos["y"] + pos["h"],
@@ -623,7 +633,7 @@ def cmd_debug(args):
         cv2.imwrite(dp, digit_crop)
         g = to_gray(digit_crop)
         dmean, dmax = float(np.mean(g)), float(np.max(g))
-        thr = _digit_threshold(g)
+        thr = _digit_threshold(g, factor=factor)
         char = read_digit(digit_crop, thr)
         seg_vis = _save_segment_vis(digit_crop, thr, prefix, i)
         print(f"  d{i}: mean={dmean:.1f}  max={dmax:.1f}  "


### PR DESCRIPTION
## Summary

Two digit recognition bugs found during calibration debug run:

**1. SEGMENT_MAP '0' vs 'O' bug** — the standard zero pattern (`0b1111110`, all segments except middle) was mapped to the letter `"O"` instead of digit `"0"`. This caused `float()` parsing in `cmd_test` to fail on zero readings. The dead `0b1110111→"0"` entry (a non-standard pattern that doesn't appear on this display) was removed at the same time.

**2. Threshold factor too low for blank digits** — with `factor=0.35`, the formula `mean + 0.35*(max-mean)` set the threshold too close to the background level when a digit position is physically unlit. Ambient IR glow raises the crop's max pixel to ~200 even for blank digits, putting the threshold at ~168 and allowing segment p90 values of 172–176 to fire as false positives.

Raising to `factor=0.50` pushes the threshold to ~178 for those same conditions, correctly suppressing blank digit positions while still detecting genuinely lit segments (which read 200+ p90). A very bright digit like `0` with all segments at 255 still reads correctly with threshold at ~217.

The factor is now a config parameter (`digit_threshold_factor`, default 0.50) so it can be tuned per-installation without code changes. The comment in the sample config explains the direction: raise toward 0.60 if blank digits still misread, lower toward 0.40 if dim lit digits are missed.

## Test plan

- [ ] `git pull` on Mac
- [ ] `python scripts/sentry-calibrate.py --debug --rtsp-url "..." --config config/config.sentry-sample.yml -o sentry-debug`
- [ ] Verify blank digit positions read `' '` instead of `'?...'` patterns
- [ ] Verify d2 reads `'0'` (digit) not `'O'` (letter)
- [ ] Check `digit_threshold_factor: 0.50` appears in debug output header line