### PR TITLE
fix: correct segment map, narrow 'a' rect, lower led_ratio to 1.15

### DIFF
--- a/config/config.sentry-sample.yml
+++ b/config/config.sentry-sample.yml
@@ -11,8 +11,9 @@ pivac.Sentry:
   frame_interval: 2.5
 
   # LED brightness ratio: how much brighter a lit LED must be vs surrounding
-  # panel background. 1.4 = 40% brighter. Works in IR and colour modes.
-  led_ratio: 1.4
+  # panel background.  Live data: lit LEDs ratio ~1.21-1.23, off LEDs ~0.79.
+  # 1.15 splits the gap cleanly.  Raise if off LEDs are false-triggering.
+  led_ratio: 1.15
 
   # Digit threshold factor: threshold = mean + factor*(max-mean) per digit crop.
   # Higher values reduce false positives on blank/dim digit positions.

--- a/scripts/sentry-calibrate.py
+++ b/scripts/sentry-calibrate.py
@@ -105,7 +105,10 @@ def _get_display_crop(frame: np.ndarray, config: dict) -> np.ndarray:
 # ---------------------------------------------------------------------------
 
 SEGMENT_RECTS = {
-    "a": (0.15, 0.00, 0.70, 0.12),  # top horizontal
+    # Fractional coords: (x_start, y_start, width, height) relative to digit crop.
+    # 'a' is narrowed to the centre of the top bar to avoid brightness spillover
+    # from the tops of the adjacent b (upper-right) and f (upper-left) verticals.
+    "a": (0.25, 0.00, 0.50, 0.12),  # top horizontal (centre only)
     "b": (0.80, 0.07, 0.15, 0.38),  # upper right vertical
     "c": (0.80, 0.55, 0.15, 0.38),  # lower right vertical
     "d": (0.15, 0.88, 0.70, 0.12),  # bottom horizontal
@@ -115,27 +118,30 @@ SEGMENT_RECTS = {
 }
 
 SEGMENT_MAP = {
-    0b1111110: "0",
-    0b0010010: "1",
-    0b1011101: "2",
-    0b1011011: "3",
-    0b0111010: "4",
-    0b1101011: "5",
-    0b1101111: "6",
-    0b1010010: "7",
-    0b1111111: "8",
-    0b1111011: "9",
-    0b1101101: "E",
-    0b0000101: "r",
-    0b1100111: "A",
-    0b1100000: "F",
-    0b0001101: "C",
-    0b0001111: "c",
-    0b1111110: "0",
-    0b0111110: "U",
-    0b0101111: "d",
-    0b0000001: "-",
-    0b0000000: " ",
+    # Standard 7-segment patterns. Bit order: a=bit6(MSB) … g=bit0(LSB).
+    # Digits
+    0b1111110: "0",   # a,b,c,d,e,f
+    0b0110000: "1",   # b,c
+    0b1101101: "2",   # a,b,d,e,g
+    0b1111001: "3",   # a,b,c,d,g
+    0b0110011: "4",   # b,c,f,g
+    0b1110011: "4",   # a,b,c,f,g  (fallback: 'a' corner spillover from b+f)
+    0b1011011: "5",   # a,c,d,f,g
+    0b1011111: "6",   # a,c,d,e,f,g
+    0b1110000: "7",   # a,b,c
+    0b1111111: "8",   # all segments
+    0b1111011: "9",   # a,b,c,d,f,g
+    # Error / status characters
+    0b1001111: "E",   # a,d,e,f,g
+    0b0000101: "r",   # e,g
+    0b1110111: "A",   # a,b,c,e,f,g
+    0b1000011: "F",   # a,f,g
+    0b1001110: "C",   # a,d,e,f
+    0b0001110: "c",   # d,e,f
+    0b0111110: "U",   # b,c,d,e,f
+    0b0111101: "d",   # b,c,d,e,g
+    0b0000001: "-",   # g
+    0b0000000: " ",   # blank
 }
 
 


### PR DESCRIPTION
## Summary

Three targeted fixes from live debug run showing display ` 45` (air=45°F, burner/circ/thermostat_demand lit):

**1. SEGMENT_RECTS 'a' narrowed** from `x=0.15–0.85` to `x=0.25–0.75`. The original width let the P90 measurement for the top-bar rect pick up brightness from the tops of the b and f vertical segments (both at 255 for digit "4"), producing a spurious `a=240` reading above the threshold. Narrowing to the centre of the top bar eliminates this overlap. The fallback map entry `0b1110011→"4"` is retained in case any spillover persists.

**2. SEGMENT_MAP rebuilt from standard 7-segment patterns.** The original map was empirically incorrect — "3" and "5" were swapped (`0b1011011` is standard "5", was mapped to "3"), the "4" pattern was wrong, and several other digits were off. Rebuilt using standard bit encoding (a=bit6…g=bit0) confirmed against the observed data point: "5"→`0b1011011` ✓.

**3. led_ratio: 1.4 → 1.15.** Live data: lit LEDs (burner/circ/thermostat_demand) ratio 1.21–1.23; off LED (circ_aux) ratio 0.79. The 1.4 threshold was above all lit readings. 1.15 splits the gap cleanly.

## Test plan

- [ ] Merge, `git pull`
- [ ] `python scripts/sentry-calibrate.py --debug --rtsp-url "..." --config config/config.sentry-sample.yml -o sentry-debug`
- [ ] d1 should read `'4'`, d2 should read `'5'`, d0 should read `' '`
- [ ] burner/circ/thermostat_demand should show `LIT`, circ_aux should show `off`
- [ ] Run `--test` to capture all 4 display modes