### PR TITLE
fix(sentry): ghost segment mapping + mode-stability guard for clean captures

### DIFF
--- a/scripts/sentry-calibrate.py
+++ b/scripts/sentry-calibrate.py
@@ -143,6 +143,12 @@ SEGMENT_MAP = {
     0b0111101: "d",   # b,c,d,e,g
     0b0000001: "-",   # g
     0b0000000: " ",   # blank
+    # Single/double-segment ghost patterns from H.264 P-frame artefacts.
+    # These appear on blank digit positions when compression noise pushes
+    # one segment rect slightly over threshold.  Not valid characters.
+    0b0010000: " ",   # c only     (lower-right ghost)
+    0b0010001: " ",   # c+g        (lower-right + middle ghost)
+    0b0010010: " ",   # c+f        (lower-right + upper-left ghost)
 }
 
 
@@ -707,8 +713,11 @@ def cmd_test(args):
     for _ in range(5):
         cap.grab()
 
+    mode_stable_min = config.get("mode_stable_frames", 3)
     collected = {}
     last_frame = None
+    prev_mode = None
+    mode_stable_count = 0
     deadline = time.time() + cycle_timeout
 
     while time.time() < deadline:
@@ -721,8 +730,19 @@ def cmd_test(args):
         value = read_display(frame, config)
         logger.info(f"  frame: display='{value}'  mode={mode}")
 
-        # Only record a clean read — skip frames where any digit is unrecognised.
-        if mode and mode not in collected and "?" not in value:
+        # Track consecutive same-mode frames to skip transition artefacts
+        # (the display may show the previous mode's value for a frame or two
+        # while the indicator light and digit segments switch simultaneously).
+        if mode == prev_mode:
+            mode_stable_count += 1
+        else:
+            prev_mode = mode
+            mode_stable_count = 0
+
+        # Only record once mode is stable and value has no unrecognised digits.
+        if (mode and mode not in collected
+                and "?" not in value
+                and mode_stable_count >= mode_stable_min):
             collected[mode] = value
             logger.info(f"  -> captured '{mode}' = '{value}'")
 
@@ -734,7 +754,7 @@ def cmd_test(args):
 
     print("\n=== Parsed display values ===")
     for mode, raw in collected.items():
-        print(f"  {mode}: raw='{raw}'", end="")
+        print(f"  {mode}: raw='{raw}", end="")
         try:
             val = float(raw)
             if mode in ("water_temp", "dhw_temp", "air"):


### PR DESCRIPTION
## Problems observed in test run

Two issues identified from `--test` output:

**1. Ghost `?0010000` on blank hundreds digit**

H.264 P-frame compression artefacts cause small brightness fluctuations between frames. On blank digit positions the c-segment rect (lower-right vertical) would occasionally fire just above threshold, producing unrecognised bit pattern `0b0010000`. This poisoned the display string with `?`, causing the clean-read guard to discard those frames — but it persisted for many consecutive frames (not just transitions), blocking capture of `air` and `gas_input` reads. Two additional ghost variants also observed: `0b0010001` (c+g) and `0b0010010` (c+f).

**2. Wrong first capture on mode transition (`air` captured as `144` not `44`)**

On the very first frame after the indicator switches from `water_temp` to `air`, the display may still be showing the tail end of the previous value. `144` has no `?`, passes the clean-read guard, and gets locked in immediately. Every subsequent frame correctly reads `44` but the captured value is already wrong.

## Fix

**`SEGMENT_MAP`** — add the three observed ghost patterns as blank (`" "`). They are not valid 7-segment characters on this display. This eliminates the `?` pollution so the c-ghost frames become `44` → captured correctly, and gas_input `0` is no longer blocked.

**`cmd_test`** — add a `mode_stable_frames` guard (default 3, config-tunable). The mode indicator must show the same mode for N consecutive frames before a value is accepted. This ensures the display has stabilised after the indicator switch before we lock in a reading.

**`config.sentry-sample.yml`** — document `mode_stable_frames: 3` (pushed to master separately).

## Expected result after merge

```
water_temp: raw='145'  ->  145.0F  =  335.93 K
air:        raw='44'   ->  44.0F   =  280.37 K
gas_input:  raw='0'    ->  gas input scale 0
dhw_temp:   raw='...'
```

No `?` in the log, `air` captured as `44` not `144`.
