### PR TITLE
fix(grafana): slow dashboard refresh to 30s to prevent SQLite lock contention

### DIFF
--- a/grafana/dashboards/pivacr.json
+++ b/grafana/dashboards/pivacr.json
@@ -3146,7 +3146,7 @@
       "type": "timeseries"
     }
   ],
-  "refresh": "5s",
+  "refresh": "30s",
   "schemaVersion": 39,
   "tags": [],
   "templating": {


### PR DESCRIPTION
## Summary

- Changes `"refresh"` from `"5s"` to `"30s"` in `pivacr.json`

5s refresh with 15+ concurrent InfluxDB queries was causing Grafana's SQLite database to lock up, producing cascading 500 errors and session auth failures. 30s eliminates the contention without requiring a database engine change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)