### PR TITLE
Grafana → Microsoft Graph email bridge + redlink-stale alert

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ htmlcov/
 # Sentry calibration/debug artifacts
 sentry-*.jpg
 test-output.txt
+
+# Claude Code local state
+.claude/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,6 +174,36 @@ serve_from_sub_path = true
 ```
 If these are lost, Grafana will redirect to `/login` with an internal URL and break the proxy.
 
+## Grafana Alerting → Microsoft Graph email bridge
+
+Grafana's built-in SMTP is disabled (DSM/M365 tenants no longer accept SMTP AUTH for outbound). Instead, alerts route to a small webhook bridge running on the Pi that calls **Microsoft Graph `sendMail`** using the same Azure AD app the bowling-league-tracker uses.
+
+**Components:**
+- `scripts/grafana_graph_bridge.py` — stdlib HTTP server listening on `127.0.0.1:8125/alert`. Reformats Grafana's webhook JSON, gets a Graph access token via client-credentials, calls `/v1.0/users/{sender}/sendMail`.
+- `scripts/systemd/grafana-graph-bridge.service` — runs as user `pi`, `EnvironmentFile=-/etc/pivac/graph.env`, `Restart=always`.
+- `/etc/pivac/graph.env` (mode 640, root:pi, **not** in the repo) — holds `GRAPH_TENANT_ID`, `GRAPH_CLIENT_ID`, `GRAPH_CLIENT_SECRET`, `GRAPH_SENDER_EMAIL`, `ALERT_RECIPIENT`. Same Azure AD app as `~utilityserver/github/bowling-league-tracker/.env` on the Mac Mini.
+- `grafana/provisioning/alerting/contact-points.yaml` — defines the `graph-bridge` webhook receiver (POSTs to the bridge) and a default policy that routes everything to it.
+- `grafana/provisioning/alerting/redlink-stale.yaml` — alert rule `redlink-stale`. Queries the last 30m of `environment.inside.thermostat.MASTER_BR.temperature`; if no samples (noData), enters Alerting state. `for: 1m` debounces, `interval: 1m` evaluates. Routes to `graph-bridge`.
+
+**Test the bridge end-to-end:**
+```bash
+curl -sS -X POST http://127.0.0.1:8125/alert -H 'Content-Type: application/json' \
+     -d '{"status":"firing","title":"test","alerts":[{"status":"firing","labels":{"alertname":"x"},"annotations":{"summary":"hello"}}]}'
+```
+Should return `ok` and an email arrives at `david@dglc.com`.
+
+**Deployment after editing the YAMLs or the bridge:**
+```bash
+# script/service:
+sudo cp ~/github/pivac/scripts/systemd/grafana-graph-bridge.service /etc/systemd/system/
+sudo systemctl daemon-reload && sudo systemctl restart grafana-graph-bridge
+# provisioning YAMLs (Grafana copies, not symlinks — must restart to pick up changes):
+sudo cp ~/github/pivac/grafana/provisioning/alerting/*.yaml /etc/grafana/provisioning/alerting/
+sudo chown root:grafana /etc/grafana/provisioning/alerting/{contact-points,redlink-stale}.yaml
+sudo chmod 640         /etc/grafana/provisioning/alerting/{contact-points,redlink-stale}.yaml
+sudo systemctl restart grafana-server
+```
+
 ## Emporia Setup (first time only)
 
 Before enabling `pivac-emporia.service`, run the discovery script to get device GIDs:

--- a/grafana/provisioning/alerting/contact-points.yaml
+++ b/grafana/provisioning/alerting/contact-points.yaml
@@ -1,0 +1,20 @@
+apiVersion: 1
+
+contactPoints:
+  - orgId: 1
+    name: graph-bridge
+    receivers:
+      - uid: graph-bridge
+        type: webhook
+        settings:
+          url: http://127.0.0.1:8125/alert
+          httpMethod: POST
+        disableResolveMessage: false
+
+policies:
+  - orgId: 1
+    receiver: graph-bridge
+    group_by: [grafana_folder, alertname]
+    group_wait: 30s
+    group_interval: 5m
+    repeat_interval: 4h

--- a/grafana/provisioning/alerting/redlink-stale.yaml
+++ b/grafana/provisioning/alerting/redlink-stale.yaml
@@ -1,0 +1,96 @@
+apiVersion: 1
+
+groups:
+  - orgId: 1
+    name: pivac-data-freshness
+    folder: pivac
+    interval: 1m
+    rules:
+      - uid: redlink-stale
+        title: RedLink data stale (>30m)
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 1800
+              to: 0
+            datasourceUid: bdxaqnfllu5fkf
+            model:
+              datasource:
+                type: influxdb
+                uid: bdxaqnfllu5fkf
+              measurement: environment.inside.thermostat.MASTER_BR.temperature
+              policy: default
+              resultFormat: time_series
+              orderByTime: ASC
+              groupBy:
+                - type: time
+                  params:
+                    - $__interval
+                - type: fill
+                  params:
+                    - none
+              select:
+                - - type: field
+                    params:
+                      - value
+                  - type: mean
+                    params: []
+              tags: []
+              refId: A
+              intervalMs: 60000
+              maxDataPoints: 43200
+          - refId: B
+            relativeTimeRange:
+              from: 1800
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: reduce
+              expression: A
+              reducer: last
+              datasource:
+                type: __expr__
+                uid: __expr__
+              refId: B
+              intervalMs: 1000
+              maxDataPoints: 43200
+          - refId: C
+            relativeTimeRange:
+              from: 1800
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: B
+              datasource:
+                type: __expr__
+                uid: __expr__
+              refId: C
+              conditions:
+                - evaluator:
+                    type: lt
+                    params:
+                      - 100
+                  operator:
+                    type: and
+                  query:
+                    params:
+                      - B
+                  reducer:
+                    type: last
+                  type: query
+              intervalMs: 1000
+              maxDataPoints: 43200
+        noDataState: Alerting
+        execErrState: Alerting
+        for: 1m
+        annotations:
+          summary: "RedLink (Honeywell thermostat) data has been stale for >30m on MASTER_BR.temperature"
+          runbook: "Check `journalctl -u pivac-redlink -n 100` for login-cooldown messages. PR #39 backoff auto-recovers within 30m on rate-limit lockouts. If lockout persists, the credentials may have been changed at mytotalconnectcomfort.com."
+        labels:
+          severity: warning
+          source: redlink
+        isPaused: false
+        notification_settings:
+          receiver: graph-bridge

--- a/scripts/grafana_graph_bridge.py
+++ b/scripts/grafana_graph_bridge.py
@@ -1,0 +1,151 @@
+"""Grafana webhook → Microsoft Graph sendMail bridge.
+
+Listens on 127.0.0.1:8125 for Grafana alerting webhook POSTs and forwards
+them as Graph sendMail calls using client-credentials OAuth2.
+
+Reads credentials from environment (set via systemd EnvironmentFile=):
+  GRAPH_TENANT_ID, GRAPH_CLIENT_ID, GRAPH_CLIENT_SECRET, GRAPH_SENDER_EMAIL
+  ALERT_RECIPIENT (defaults to GRAPH_SENDER_EMAIL)
+
+Pattern lifted directly from bowling-league-tracker/check_health.py — same
+Azure AD app/secret works for both.
+"""
+
+import json
+import logging
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+LISTEN_HOST = '127.0.0.1'
+LISTEN_PORT = 8125
+
+logger = logging.getLogger('grafana-graph-bridge')
+
+
+def _graph_token(tenant_id, client_id, client_secret):
+    data = urllib.parse.urlencode({
+        'grant_type':    'client_credentials',
+        'client_id':     client_id,
+        'client_secret': client_secret,
+        'scope':         'https://graph.microsoft.com/.default',
+    }).encode()
+    req = urllib.request.Request(
+        f'https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token',
+        data=data, method='POST',
+    )
+    with urllib.request.urlopen(req, timeout=15) as r:
+        return json.loads(r.read())['access_token']
+
+
+def _send_email(subject, html_body):
+    tenant_id     = os.environ['GRAPH_TENANT_ID']
+    client_id     = os.environ['GRAPH_CLIENT_ID']
+    client_secret = os.environ['GRAPH_CLIENT_SECRET']
+    sender        = os.environ['GRAPH_SENDER_EMAIL']
+    recipient     = os.environ.get('ALERT_RECIPIENT', sender)
+
+    token = _graph_token(tenant_id, client_id, client_secret)
+    payload = json.dumps({
+        'message': {
+            'subject': subject,
+            'body':    {'contentType': 'HTML', 'content': html_body},
+            'toRecipients': [{'emailAddress': {'address': recipient}}],
+        },
+        'saveToSentItems': True,
+    }).encode()
+    req = urllib.request.Request(
+        f'https://graph.microsoft.com/v1.0/users/{sender}/sendMail',
+        data=payload,
+        headers={
+            'Authorization': f'Bearer {token}',
+            'Content-Type':  'application/json',
+        },
+        method='POST',
+    )
+    with urllib.request.urlopen(req, timeout=15):
+        pass  # 202 Accepted
+
+
+def _format_alert(payload):
+    """Render Grafana's webhook JSON into a subject + HTML body."""
+    status = payload.get('status', 'unknown')
+    title  = payload.get('title') or payload.get('message') or 'Grafana alert'
+    alerts = payload.get('alerts', [])
+
+    subject = f'[Grafana {status.upper()}] {title}'
+
+    rows = []
+    for a in alerts:
+        labels = a.get('labels', {})
+        annot  = a.get('annotations', {})
+        rows.append(
+            f'<li><strong>{a.get("status", "")}</strong> — '
+            f'<code>{labels.get("alertname", "?")}</code><br>'
+            f'{annot.get("summary", "")}<br>'
+            f'<small>{annot.get("runbook", "")}</small></li>'
+        )
+
+    html = (
+        f'<p><strong>Status:</strong> {status}</p>'
+        f'<p><strong>Title:</strong> {title}</p>'
+        f'<ul>{"".join(rows)}</ul>'
+        f'<hr><pre>{json.dumps(payload, indent=2)[:4000]}</pre>'
+    )
+    return subject, html
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_POST(self):
+        if self.path != '/alert':
+            self.send_response(404)
+            self.end_headers()
+            return
+
+        length = int(self.headers.get('Content-Length', '0'))
+        try:
+            payload = json.loads(self.rfile.read(length) or b'{}')
+        except json.JSONDecodeError as e:
+            logger.warning('bad JSON: %s', e)
+            self.send_response(400)
+            self.end_headers()
+            return
+
+        subject, html = _format_alert(payload)
+        try:
+            _send_email(subject, html)
+            logger.info('sent: %s', subject)
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b'ok')
+        except Exception as e:
+            logger.exception('graph send failed')
+            self.send_response(502)
+            self.end_headers()
+            self.wfile.write(f'graph error: {e}'.encode())
+
+    def log_message(self, fmt, *args):
+        logger.info('%s - %s', self.client_address[0], fmt % args)
+
+
+def main():
+    logging.basicConfig(
+        format='%(asctime)s %(levelname)s %(name)s: %(message)s',
+        level=logging.INFO,
+        stream=sys.stderr,
+    )
+    for k in ('GRAPH_TENANT_ID', 'GRAPH_CLIENT_ID', 'GRAPH_CLIENT_SECRET', 'GRAPH_SENDER_EMAIL'):
+        if not os.environ.get(k):
+            logger.error('missing required env var: %s', k)
+            sys.exit(1)
+
+    server = ThreadingHTTPServer((LISTEN_HOST, LISTEN_PORT), Handler)
+    logger.info('listening on http://%s:%d/alert', LISTEN_HOST, LISTEN_PORT)
+    server.serve_forever()
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/systemd/grafana-graph-bridge.service
+++ b/scripts/systemd/grafana-graph-bridge.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Grafana webhook → Microsoft Graph sendMail bridge
+After=network-online.target grafana-server.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=pi
+EnvironmentFile=-/etc/pivac/graph.env
+ExecStart=/home/pi/pivac-venv/bin/python3 /home/pi/github/pivac/scripts/grafana_graph_bridge.py
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

- New webhook→Graph bridge service (`grafana-graph-bridge.service`) so Grafana alerting can deliver email via Microsoft Graph instead of SMTP. Reuses the same Azure AD app the bowling-league-tracker app uses; credentials live in `/etc/pivac/graph.env` (gitignored, mode 640 root:pi).
- First alert rule provisioned: `redlink-stale` fires when `environment.inside.thermostat.MASTER_BR.temperature` has no samples in the last 30 min. Catches the kind of multi-day Honeywell rate-limit lockouts that PR #39's backoff is designed to recover from (we saw two such windows in the 90-day data: Feb 8 → Mar 13 and Mar 24 → Mar 30).
- CLAUDE.md gets a new \"Grafana Alerting → Microsoft Graph email bridge\" section documenting components, deploy steps, and an end-to-end curl test.
- Adds `.claude/` to `.gitignore` (Claude Code session state was accumulating in working tree).

## Test plan

- [x] Bridge service starts cleanly under systemd, listens on `127.0.0.1:8125`
- [x] Test webhook (`curl -sS -X POST http://127.0.0.1:8125/alert -H 'Content-Type: application/json' -d '...'`) returns `ok`
- [x] Email arrives at `david@dglc.com` from `david@dglc.com` (test confirmed during development)
- [x] Grafana 13 accepts both provisioning YAMLs at startup (no errors in journalctl)
- [ ] Verify alert actually fires when redlink data goes stale — to confirm next time pivac-redlink is stopped for >30m

🤖 Generated with [Claude Code](https://claude.com/claude-code)