### PR TITLE
feat(RedLink): health metrics + faster diagnostic alerts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,7 +183,10 @@ Grafana's built-in SMTP is disabled (DSM/M365 tenants no longer accept SMTP AUTH
 - `scripts/systemd/grafana-graph-bridge.service` — runs as user `pi`, `EnvironmentFile=-/etc/pivac/graph.env`, `Restart=always`.
 - `/etc/pivac/graph.env` (mode 640, root:pi, **not** in the repo) — holds `GRAPH_TENANT_ID`, `GRAPH_CLIENT_ID`, `GRAPH_CLIENT_SECRET`, `GRAPH_SENDER_EMAIL`, `ALERT_RECIPIENT`. Same Azure AD app as `~utilityserver/github/bowling-league-tracker/.env` on the Mac Mini.
 - `grafana/provisioning/alerting/contact-points.yaml` — defines the `graph-bridge` webhook receiver (POSTs to the bridge) and a default policy that routes everything to it.
-- `grafana/provisioning/alerting/redlink-stale.yaml` — alert rule `redlink-stale`. Queries the last 30m of `environment.inside.thermostat.MASTER_BR.temperature`; if no samples (noData), enters Alerting state. `for: 1m` debounces, `interval: 1m` evaluates. Routes to `graph-bridge`.
+- `grafana/provisioning/alerting/redlink-stale.yaml` — three RedLink alerts, all routing to `graph-bridge`:
+  - `redlink-stale` (warning) — last 30m of `environment.inside.thermostat.MASTER_BR.temperature`. Canonical "definitely broken" signal. `noDataState: Alerting`.
+  - `redlink-stale-fast` (info) — same metric, 10m window. Earlier warning that data flow has stopped. `noDataState: Alerting`.
+  - `redlink-error-burst` (warning) — fires when `environment.inside.thermostat.redlink.consecutiveErrors > 2` for 5m. Reads the new health-counter the module emits every cycle. `noDataState: OK` (the freshness alerts cover the no-data case). The runbook in the alert directs the responder to query `environment.inside.thermostat.redlink.lastErrorType` to identify the failure mode (e.g. `UnexpectedResponse` = aiosomecomfort can't parse Honeywell's reply, signal that the library or scraper fallback may be needed).
 
 **Test the bridge end-to-end:**
 ```bash

--- a/grafana/provisioning/alerting/redlink-stale.yaml
+++ b/grafana/provisioning/alerting/redlink-stale.yaml
@@ -87,7 +87,199 @@ groups:
         for: 1m
         annotations:
           summary: "RedLink (Honeywell thermostat) data has been stale for >30m on MASTER_BR.temperature"
-          runbook: "Check `journalctl -u pivac-redlink -n 100` for login-cooldown messages. PR #39 backoff auto-recovers within 30m on rate-limit lockouts. If lockout persists, the credentials may have been changed at mytotalconnectcomfort.com."
+          runbook: |
+            1. `journalctl -u pivac-redlink -n 100 --no-pager` — look for the most recent ERROR entries.
+            2. Query `environment.inside.thermostat.redlink.lastErrorType` in Signal K / InfluxDB to see the last failure mode emitted by the module.
+            3. Likely causes (most → least common):
+               - `UnexpectedResponse` / `AllDevicesFailed`: aiosomecomfort can't parse Honeywell's reply — Honeywell may have changed the mobile API. Check upstream library for an update; consider reviving the old scraper as a fallback.
+               - `AuthError`: credentials in `/etc/pivac/config.yml` may have changed at mytotalconnectcomfort.com.
+               - `APIRateLimited`: persistent 600s rate limit; usually self-recovers.
+               - `TimeoutError` / `ConnectionError`: Pi network or Honeywell endpoint slow; usually self-recovers.
+        labels:
+          severity: warning
+          source: redlink
+        isPaused: false
+        notification_settings:
+          receiver: graph-bridge
+
+      - uid: redlink-stale-fast
+        title: RedLink data stale (>10m)
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: bdxaqnfllu5fkf
+            model:
+              datasource:
+                type: influxdb
+                uid: bdxaqnfllu5fkf
+              measurement: environment.inside.thermostat.MASTER_BR.temperature
+              policy: default
+              resultFormat: time_series
+              orderByTime: ASC
+              groupBy:
+                - type: time
+                  params:
+                    - $__interval
+                - type: fill
+                  params:
+                    - none
+              select:
+                - - type: field
+                    params:
+                      - value
+                  - type: mean
+                    params: []
+              tags: []
+              refId: A
+              intervalMs: 60000
+              maxDataPoints: 43200
+          - refId: B
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: reduce
+              expression: A
+              reducer: last
+              datasource:
+                type: __expr__
+                uid: __expr__
+              refId: B
+              intervalMs: 1000
+              maxDataPoints: 43200
+          - refId: C
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: B
+              datasource:
+                type: __expr__
+                uid: __expr__
+              refId: C
+              conditions:
+                - evaluator:
+                    type: lt
+                    params:
+                      - 100
+                  operator:
+                    type: and
+                  query:
+                    params:
+                      - B
+                  reducer:
+                    type: last
+                  type: query
+              intervalMs: 1000
+              maxDataPoints: 43200
+        noDataState: Alerting
+        execErrState: Alerting
+        for: 1m
+        annotations:
+          summary: "RedLink data stale for >10m on MASTER_BR.temperature (early warning)"
+          runbook: "Same triage as the 30m alert — see `redlink-stale` runbook. This rule fires earlier; the 30m rule is the canonical 'definitely broken' signal."
+        labels:
+          severity: info
+          source: redlink
+        isPaused: false
+        notification_settings:
+          receiver: graph-bridge
+
+      - uid: redlink-error-burst
+        title: RedLink module reporting sustained errors
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: bdxaqnfllu5fkf
+            model:
+              datasource:
+                type: influxdb
+                uid: bdxaqnfllu5fkf
+              measurement: environment.inside.thermostat.redlink.consecutiveErrors
+              policy: default
+              resultFormat: time_series
+              orderByTime: ASC
+              groupBy:
+                - type: time
+                  params:
+                    - $__interval
+                - type: fill
+                  params:
+                    - none
+              select:
+                - - type: field
+                    params:
+                      - value
+                  - type: max
+                    params: []
+              tags: []
+              refId: A
+              intervalMs: 60000
+              maxDataPoints: 43200
+          - refId: B
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: reduce
+              expression: A
+              reducer: last
+              datasource:
+                type: __expr__
+                uid: __expr__
+              refId: B
+              intervalMs: 1000
+              maxDataPoints: 43200
+          - refId: C
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: B
+              datasource:
+                type: __expr__
+                uid: __expr__
+              refId: C
+              conditions:
+                - evaluator:
+                    type: gt
+                    params:
+                      - 2
+                  operator:
+                    type: and
+                  query:
+                    params:
+                      - B
+                  reducer:
+                    type: last
+                  type: query
+              intervalMs: 1000
+              maxDataPoints: 43200
+        noDataState: OK
+        execErrState: OK
+        for: 5m
+        annotations:
+          summary: "RedLink module reporting sustained errors (consecutiveErrors > 2 for 5m)"
+          runbook: |
+            The pivac.RedLink module has logged 3+ consecutive failures over the last 5 minutes.
+            Query `environment.inside.thermostat.redlink.lastErrorType` to see the failure mode:
+              - `UnexpectedResponse` / `AllDevicesFailed`: aiosomecomfort can't parse Honeywell's reply — likely API change, check upstream library / consider scraper fallback.
+              - `AuthError`: credentials may have changed.
+              - `TimeoutError` / `ConnectionError`: transient, usually self-recovers within minutes.
+              - `APIRateLimited`: 600s cooldown, self-recovers.
+            `noDataState: OK` so this rule stays quiet during the >10m gaps the freshness alerts cover.
         labels:
           severity: warning
           source: redlink

--- a/pivac/RedLink.py
+++ b/pivac/RedLink.py
@@ -27,6 +27,13 @@ _session = None
 _client = None
 _lock = threading.Lock()
 
+# Health state — exported as SK values every cycle so Grafana can alert on
+# sustained errors without waiting for the freshness rule to time out.
+# `_last_error_type` is "" on success, otherwise the exception class name
+# (AuthError, APIRateLimited, UnexpectedResponse, TimeoutError, ...).
+_consecutive_errors = 0
+_last_error_type = ""
+
 _STATENUMS = {"heat": 1, "cool": -1, "fan": 0.5, "off": 0}
 
 
@@ -101,6 +108,8 @@ def _to_kelvin(value, scale):
 
 
 def status(config={}, output="default"):
+    global _consecutive_errors, _last_error_type
+
     if "uid" not in config or "pwd" not in config:
         logger.error("Credentials not specified in config file.")
         raise ValueError
@@ -110,18 +119,27 @@ def status(config={}, output="default"):
     timeout = config.get("request_timeout", 30)
     inputs = config.get("inputs", {})
 
+    inside_path = inputs.get("thermostat", {}).get(
+        "sk_path", "environment.inside.thermostat"
+    )
+    outside_path = inputs.get("outdoor_sensor", {}).get(
+        "sk_path", "environment.outside.thermostat"
+    )
+
+    devices = None
+    error = None
     with _lock:
         try:
             _run(_connect(uid, pwd, timeout))
             devices = _run(_refresh_all())
-        except aiosomecomfort.AuthError:
+        except aiosomecomfort.AuthError as e:
             logger.exception("Honeywell auth failed")
+            error = e
             _run(_reset())
-            raise IOError
-        except aiosomecomfort.APIRateLimited:
+        except aiosomecomfort.APIRateLimited as e:
             logger.warning("Honeywell rate-limited; will retry next cycle")
+            error = e
             _run(_reset())
-            raise IOError
         except (
             aiosomecomfort.ConnectionError,
             aiosomecomfort.ConnectionTimeout,
@@ -130,24 +148,41 @@ def status(config={}, output="default"):
             aiosomecomfort.ServiceUnavailable,
         ) as e:
             logger.warning("RedLink transient error: %s: %s", type(e).__name__, e)
+            error = e
             _run(_reset())
-            raise IOError
-        except Exception:
+        except Exception as e:
             logger.exception("RedLink unexpected error")
+            error = e
             _run(_reset())
-            raise IOError
 
-    inside_path = inputs.get("thermostat", {}).get(
-        "sk_path", "environment.inside.thermostat"
-    )
-    outside_path = inputs.get("outdoor_sensor", {}).get(
-        "sk_path", "environment.outside.thermostat"
-    )
+    if error is not None:
+        _consecutive_errors += 1
+        _last_error_type = type(error).__name__
+    elif not devices:
+        # connect/login worked but every device refresh failed individually
+        _consecutive_errors += 1
+        _last_error_type = "AllDevicesFailed"
+    else:
+        _consecutive_errors = 0
+        _last_error_type = ""
 
+    # Surface health metrics every cycle (success or failure) so Grafana can
+    # alert on sustained errors without waiting for the data-freshness rule.
+    # On error we return a deltas object containing only the health values —
+    # the orchestrator pushes them to Signal K, while existing thermostat
+    # values age out and the redlink-stale alerts eventually fire too.
     if output == "signalk":
         from pivac import sk_init_deltas, sk_add_source, sk_add_value
         deltas = sk_init_deltas()
         sk_source = sk_add_source(deltas)
+        sk_add_value(sk_source, f"{inside_path}.redlink.consecutiveErrors", _consecutive_errors)
+        sk_add_value(sk_source, f"{inside_path}.redlink.lastErrorType", _last_error_type)
+        if not devices:
+            return deltas
+
+    if not devices:
+        # default-output callers (manual scripts, tests) still want to see errors.
+        raise IOError(f"RedLink poll failed: {_last_error_type} (consecutive={_consecutive_errors})")
 
     result = {}
     outdoor_humidity_pct = None


### PR DESCRIPTION
## Summary

Adds early-warning + diagnostic monitoring for the RedLink module, so we can catch aiosomecomfort/Honeywell-API breakage in minutes (not 30) and tell *what* broke from the alert email.

**Module** (`pivac/RedLink.py`):
- Track `_consecutive_errors` and `_last_error_type` across calls.
- Emit two SK values every cycle: `environment.inside.thermostat.redlink.{consecutiveErrors, lastErrorType}`.
- On error, the module no longer raises `IOError` to the orchestrator — it returns a deltas object containing only the health values, so Grafana sees the failure state in real time. Default-output callers (manual scripts, tests) still get an `IOError`.

**Grafana** (`grafana/provisioning/alerting/redlink-stale.yaml`):
- `redlink-stale-fast` (info, 10m) — earlier copy of the canonical 30m freshness alert.
- `redlink-error-burst` (warning, 5m) — fires when `consecutiveErrors > 2` for 5m. Runbook points to `lastErrorType` to identify the failure mode.
- Updated `redlink-stale` runbook to mention `aiosomecomfort` + scraper-revival fallback as likely causes.

## Test plan

- [x] Verified success path emits `consecutiveErrors=0, lastErrorType=""`.
- [x] Verified simulated `AuthError` (bogus password) emits `consecutiveErrors=1, lastErrorType="AuthError"` with a deltas object containing only the two health values.
- [x] All three alert rules parse cleanly via `yaml.safe_load`.
- [ ] Merge → on Pi: `git pull && sudo systemctl restart pivac-redlink && sudo cp grafana/provisioning/alerting/redlink-stale.yaml /etc/grafana/provisioning/alerting/ && sudo chown root:grafana /etc/grafana/provisioning/alerting/redlink-stale.yaml && sudo chmod 640 /etc/grafana/provisioning/alerting/redlink-stale.yaml && sudo systemctl restart grafana-server`.
- [ ] Confirm in Grafana UI that all three rules show up under the `pivac` folder, in `Normal` state.
- [ ] Confirm `environment.inside.thermostat.redlink.consecutiveErrors` is being written to InfluxDB (`influx query 'import "influxdata/influxdb/schema" schema.measurements(bucket: "pivac")' | grep redlink`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)