### PR TITLE
feat: monthly automated NAS image-backup via systemd timer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -226,9 +226,9 @@ sudo systemctl restart pivac-1wire pivac-redlink pivac-gpio pivac-arduino-psi pi
 journalctl -u pivac-1wire -u pivac-redlink -u pivac-gpio -u pivac-arduino-psi -u pivac-arduino-therm-psi -u pivac-emporia -u pivac-sentry -n 50 --no-pager
 ```
 
-If systemd service files were changed:
+If systemd service or timer files were changed:
 ```bash
-sudo cp ~/github/pivac/scripts/systemd/*.service /etc/systemd/system/
+sudo cp ~/github/pivac/scripts/systemd/*.service ~/github/pivac/scripts/systemd/*.timer /etc/systemd/system/
 sudo systemctl daemon-reload
 ```
 
@@ -237,6 +237,10 @@ sudo systemctl daemon-reload
 sudo systemctl stop pivac-1wire pivac-redlink pivac-gpio pivac-arduino-psi pivac-arduino-therm-psi pivac-emporia pivac-sentry signalk influxdb nginx
 ```
 Stop order matters: pivac services first (they push to Signal K), then signalk (writes its own store and feeds influxdb), then influxdb (the database), then nginx (terminates external connections including the `mlb.dglc.com` bowling proxy). The bowling app DB is on the Mac Mini — stop `com.dglc.bowling-app` there separately if doing Mac maintenance. Services with `Restart=always` will restart automatically on boot; nginx does not, so start it explicitly after the swap: `sudo systemctl start nginx`.
+
+## Backup Automation
+
+`nas-image-backup.timer` runs `nas-image-backup.service` on the 1st of each month at 03:00 EDT. The service runs `scripts/nas-image-backup.sh`, which mounts the NFS share, stops the disk-writing services listed above, runs `image-backup` against `/mnt/nas-pi-backups/pivac.img`, and restarts services on EXIT. Typical incremental: ~2 minutes downtime. See `~/CLAUDE.md` Backup section for the full architecture (NAS share, NFS+ACL gotcha, bootstrap caveats).
 
 ## Checking Logs
 

--- a/scripts/nas-image-backup.sh
+++ b/scripts/nas-image-backup.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Monthly incremental image-backup of the live Pi filesystem into the
+# NFS-mounted .img on LookoutNas. Stops the documented set of disk-writing
+# services for a clean rsync, then restarts them — even on failure.
+#
+# Triggered by nas-image-backup.timer; can also be run manually as root.
+set -u -o pipefail
+
+NAS_MOUNT=/mnt/nas-pi-backups
+NAS_IMG=$NAS_MOUNT/pivac.img
+IMG_BACKUP=/home/pi/github/RonR-RPi-image-utils/image-backup
+
+STOP_SVCS=(pivac-1wire pivac-redlink pivac-gpio pivac-arduino-psi
+           pivac-arduino-therm-psi pivac-emporia pivac-sentry
+           signalk influxdb nginx)
+START_SVCS=(nginx signalk influxdb pivac-1wire pivac-redlink pivac-gpio
+            pivac-arduino-psi pivac-arduino-therm-psi pivac-emporia pivac-sentry)
+
+log() { echo "[$(date -Is)] $*"; }
+
+if [[ $EUID -ne 0 ]]; then
+    log "ERROR: must run as root"
+    exit 1
+fi
+
+if ! mountpoint -q "$NAS_MOUNT"; then
+    log "mounting $NAS_MOUNT"
+    mount "$NAS_MOUNT" || { log "ERROR: mount failed"; exit 1; }
+fi
+
+if [[ ! -f $NAS_IMG ]]; then
+    log "ERROR: $NAS_IMG missing — refusing to bootstrap from a timer"
+    exit 1
+fi
+
+trap 'log "restarting services"; systemctl start "${START_SVCS[@]}" || true' EXIT
+
+log "stopping services: ${STOP_SVCS[*]}"
+systemctl stop "${STOP_SVCS[@]}"
+
+log "starting incremental against $NAS_IMG"
+T0=$(date +%s)
+"$IMG_BACKUP" "$NAS_IMG"
+RC=$?
+T1=$(date +%s)
+ELAPSED=$((T1 - T0))
+log "incremental finished — exit $RC — elapsed ${ELAPSED}s ($((ELAPSED/60))m $((ELAPSED%60))s)"
+
+exit $RC

--- a/scripts/systemd/nas-image-backup.service
+++ b/scripts/systemd/nas-image-backup.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Monthly Pi image-backup to LookoutNas
+Documentation=file:///home/pi/CLAUDE.md
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/home/pi/github/pivac/scripts/nas-image-backup.sh
+TimeoutStartSec=2h
+StandardOutput=journal
+StandardError=journal

--- a/scripts/systemd/nas-image-backup.timer
+++ b/scripts/systemd/nas-image-backup.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run nas-image-backup monthly
+
+[Timer]
+OnCalendar=*-*-01 03:00:00
+Persistent=true
+RandomizedDelaySec=15min
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary

- Adds `nas-image-backup.timer` (1st of month, 03:00 EDT) and `nas-image-backup.service` to automate monthly incremental image-backups to LookoutNas.
- Adds `scripts/nas-image-backup.sh`, the script the service runs — mounts NFS, stops disk-writing services in the documented order, runs `image-backup` against `/mnt/nas-pi-backups/pivac.img`, and restarts services on EXIT (even on failure).
- Updates `pivac/CLAUDE.md` with a brief Backup Automation section pointing readers at the full architecture in `~/CLAUDE.md` (pi-CLAUDE.md).

## Why

The bootstrap copy of the 55 GB sparse `.img` to the NAS finished today (2026-05-08), and a benchmark of the first NAS-direct incremental took **127 seconds**. That validates the original plan from pi-CLAUDE.md (NAS-direct monthly incrementals) — rsync-over-NFS only starves on initial bulk copy, not on incrementals into a loop-mounted `.img`. With ~2 minutes of monthly downtime, automating it is cheap insurance against forgetting to run it.

## Test plan

- [x] Timer + service installed on Pi (`/etc/systemd/system/nas-image-backup.{service,timer}`)
- [x] `systemctl list-timers nas-image-backup.timer` confirms next run at 2026-06-01 03:01:41 EDT
- [x] Bench run earlier today (in `/tmp/nas-bench.sh`) validated the same exec path: stop services → image-backup → restart, 127 s elapsed
- [ ] First scheduled run on 2026-06-01 — check `journalctl -u nas-image-backup.service` afterward

🤖 Generated with [Claude Code](https://claude.com/claude-code)