### PR TITLE
fix(RedLink): scope 12s timeout to per-refresh deadline, not the aiosomecomfort client

### DIFF
--- a/config/config.yml.sample
+++ b/config/config.yml.sample
@@ -110,12 +110,12 @@ pivac.RedLink:
     # how long to sleep in sec between status calls. Default (if absent) is 0.5 sec
     daemon_sleep: 2
 
-    # socket timeout in seconds per HTTP request to the Honeywell mobile API.
-    # Refreshes for all thermostats run in parallel (asyncio.gather), so this
-    # is also the worst-case cycle time when one device stalls — keeping it
-    # short prevents a single slow device from delaying the published delta.
-    # Typical refresh: 1–3s on macOS, 5–15s on the Pi with force_close=TLS.
-    request_timeout: 12
+    # socket timeout in seconds for the aiosomecomfort client (governs the
+    # login flow on cold start). Cold-start login on the Pi takes ~75s due
+    # to Honeywell's redirect-heavy login + TLS handshakes, so keep this
+    # generous. Per-device refresh latency is bounded separately by
+    # REFRESH_DEADLINE (12s) inside RedLink.py.
+    request_timeout: 30
 
     # website
     site: "https://www.mytotalconnectcomfort.com/portal"

--- a/pivac/RedLink.py
+++ b/pivac/RedLink.py
@@ -28,6 +28,13 @@ logger = logging.getLogger(__name__)
 # `redlink-stale-fast` (10m) freshness alert fires.
 CYCLE_WARN_THRESHOLD = 20.0
 
+# Hard per-device deadline for `dev.refresh()`. Independent of the config's
+# `request_timeout` (which governs the aiosomecomfort client used for login —
+# cold-start login on the Pi takes ~75s and must not be cut short). With
+# refreshes parallelised, this is the worst-case cycle time when one device
+# stalls: a single slow thermostat can no longer drag the others past it.
+REFRESH_DEADLINE = 12.0
+
 _loop = None
 _loop_thread = None
 _session = None
@@ -80,7 +87,7 @@ async def _connect(uid, pwd, timeout):
 
 async def _refresh_one(dev):
     try:
-        await dev.refresh()
+        await asyncio.wait_for(dev.refresh(), timeout=REFRESH_DEADLINE)
         return dev
     except (asyncio.TimeoutError, aiosomecomfort.ConnectionTimeout,
             aiosomecomfort.ConnectionError) as e:


### PR DESCRIPTION
## Summary

PR #45 lowered `request_timeout` from 30 → 12 in `config.yml.sample`. That broke cold-start login on the Pi: aiosomecomfort needs ~75s for the redirect-heavy login flow (documented in CLAUDE.md), so a 12s client-wide timeout caused an \`AuthError: Null cookie connection error 200\` loop on every login attempt.

This commit restores `request_timeout: 30` and applies the 12s ceiling only to `dev.refresh()` via `asyncio.wait_for` inside `_refresh_one`. Login keeps the long timeout it needs; refresh keeps the short, parallel-safe deadline that was the actual goal.

## Verified on Pi

After PR #45 deployed with the original 12s `request_timeout`, the journal showed AuthError + TimeoutError on every cycle. Reverting `/etc/pivac/config.yml` to `request_timeout: 30` immediately stopped the loop and the service returned to its baseline.

## Test plan

- [ ] Merge, pull on Pi, restart `pivac-redlink`
- [ ] Wait ~90s for cold-start login to complete
- [ ] Confirm no \`AuthError: Null cookie\` in the journal
- [ ] Watch SK timestamp on `environment.inside.thermostat.MASTER_BR.temperature` for 3+ min — gaps should stay near `daemon_sleep` (15s) plus refresh latency, well below the pre-fix 30–75s sequential cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)