### PR TITLE
fix(RedLink): split login from discover, stop resetting session on transient timeouts

### DIFF
--- a/pivac/RedLink.py
+++ b/pivac/RedLink.py
@@ -81,7 +81,21 @@ async def _connect(uid, pwd, timeout):
         _client = aiosomecomfort.AIOSomeComfort(
             uid, pwd, timeout=timeout, session=_session
         )
-        await _client.login()
+        try:
+            await _client.login()
+        except Exception:
+            # Login failed before completing — drop the half-built client so
+            # next cycle retries cleanly. Without this, _client would survive
+            # but be unusable.
+            _client = None
+            raise
+    # Discover is split from login: aiosomecomfort.discover() does five
+    # *sequential* device fetches internally, each subject to the aiohttp
+    # request_timeout (30s). On the Pi a single slow Honeywell response
+    # kills the whole discover, but the login session is still good. Keep
+    # _client and let the next cycle retry just the discover step — saves
+    # the ~75s cold-start login from happening on every transient failure.
+    if not _client.locations_by_id:
         await _client.discover()
 
 
@@ -169,6 +183,7 @@ def status(config={}, output="default"):
 
     devices = None
     error = None
+    must_reset = False
     cycle_start = time.monotonic()
     with _lock:
         try:
@@ -177,24 +192,35 @@ def status(config={}, output="default"):
         except aiosomecomfort.AuthError as e:
             logger.exception("Honeywell auth failed")
             error = e
-            _run(_reset())
+            must_reset = True  # auth is bad, must re-login
         except aiosomecomfort.APIRateLimited as e:
             logger.warning("Honeywell rate-limited; will retry next cycle")
             error = e
-            _run(_reset())
+            must_reset = True  # MIN_LOGIN_TIME guard, full reset to back off
+        except aiosomecomfort.SessionTimedOut as e:
+            logger.warning("RedLink session timed out; resetting")
+            error = e
+            must_reset = True  # session is dead
         except (
             aiosomecomfort.ConnectionError,
             aiosomecomfort.ConnectionTimeout,
-            aiosomecomfort.SessionTimedOut,
             aiosomecomfort.UnexpectedResponse,
             aiosomecomfort.ServiceUnavailable,
         ) as e:
             logger.warning("RedLink transient error: %s: %s", type(e).__name__, e)
             error = e
-            _run(_reset())
+            # Session is probably still good — let the next cycle retry. A
+            # full _reset() here would force a ~75s re-login for what is
+            # often a single slow request from Honeywell.
         except Exception as e:
-            logger.exception("RedLink unexpected error")
+            # Catches asyncio.TimeoutError from aiohttp's internal request
+            # timer (a single HTTP call exceeded the client timeout). The
+            # session is almost certainly still valid; reset only if we're
+            # sure something is broken.
+            logger.exception("RedLink unexpected error: %s", type(e).__name__)
             error = e
+
+        if must_reset:
             _run(_reset())
 
     cycle_elapsed = time.monotonic() - cycle_start


### PR DESCRIPTION
## Summary

PR #47 didn't actually fix the freshness problem — post-deploy, every cycle was 60–90s with `RedLink unexpected error` (CancelledError → TimeoutError) and the same SK timestamp held for 2+ minutes at a time. Live traceback at 16:29:54 EDT showed where the error actually originated:

\`\`\`
File "pivac/RedLink.py", line 175, in status
    _run(_connect(uid, pwd, timeout))
File "pivac/RedLink.py", line 85, in _connect
    await _client.discover()
...
File "aiosomecomfort/device.py", line 60, in refresh
    data = await self._client.get_thermostat_data(self.deviceid)
File "aiohttp/helpers.py", line 713, in __exit__
    raise asyncio.TimeoutError from exc_val
\`\`\`

`aiosomecomfort.discover()` does **five sequential `device.refresh()` calls inside the library** (one per thermostat), each subject to aiohttp's 30s `request_timeout`. On the Pi a single slow Honeywell response kills the whole discover, and the previous code's outer `except Exception → _reset()` then nuked the auth session — forcing every next cycle to redo the full ~75s cold-start login + sequential 5-thermostat discover all over again.

## Two fixes

1. **Split login from discover in `_connect()`.** If discover fails after a successful login, the next cycle just retries discover — no re-login. The ~75s login cost happens once at startup, not every error.
2. **Don't `_reset()` on transient request timeouts.** Reset only for AuthError, APIRateLimited, and SessionTimedOut (signals that the session is actually dead). For ConnectionError, TimeoutError, UnexpectedResponse, ServiceUnavailable: keep the session, retry next cycle.

## Deploy

Same as before — pull on Pi, restart `pivac-redlink`. No config changes this round.

## Test plan

- [ ] After deploy, cold-start cycle 1 takes ~75s (login + first discover) — expected
- [ ] Cycle 2+ should be 5–15s (parallel refresh only, session cached)
- [ ] No \`RedLink unexpected error\` tracebacks in steady state
- [ ] SK timestamps update every 10–17s (5s daemon_sleep + 5–12s cycle)
- [ ] WilhelmSK widgets stay live through a 5-minute observation window

🤖 Generated with [Claude Code](https://claude.com/claude-code)