### PR TITLE
tweak(RedLink): raise REFRESH_DEADLINE 12s → 20s for slow Honeywell devices

### DIFF
--- a/pivac/RedLink.py
+++ b/pivac/RedLink.py
@@ -26,14 +26,19 @@ logger = logging.getLogger(__name__)
 # seconds. Healthy cycles run 5–15s; sustained values above this threshold
 # show up as stale-data flicker in WilhelmSK widgets long before the
 # `redlink-stale-fast` (10m) freshness alert fires.
-CYCLE_WARN_THRESHOLD = 20.0
+CYCLE_WARN_THRESHOLD = 30.0
 
 # Hard per-device deadline for `dev.refresh()`. Independent of the config's
 # `request_timeout` (which governs the aiosomecomfort client used for login —
 # cold-start login on the Pi takes ~75s and must not be cut short). With
 # refreshes parallelised, this is the worst-case cycle time when one device
 # stalls: a single slow thermostat can no longer drag the others past it.
-REFRESH_DEADLINE = 12.0
+# 20s gives Honeywell's flaky per-device API enough rope to succeed on the
+# Pi (per-device latency averages 5–10s with occasional 15s+ outliers);
+# tightening this further produced too many false-timeout failures and made
+# specific paths (e.g. MASTER_BR.temperature) flicker stale in WilhelmSK
+# whenever they happened to time out 2–3 cycles in a row.
+REFRESH_DEADLINE = 20.0
 
 _loop = None
 _loop_thread = None


### PR DESCRIPTION
## Summary

Live data after PR #48 confirmed our code is no longer the bottleneck — it's Honeywell's per-device API on the Pi. Per-device refresh latency averages 5–10s with regular 15s+ outliers (force_close=True forces a fresh TLS handshake on every refresh). At the existing 12s `wait_for` cap, several devices were timing out per cycle, and when MASTER_BR happened to time out 2–3 cycles in a row that path went visibly stale in WilhelmSK for 30–60s.

Bump `REFRESH_DEADLINE` from 12s → 20s to give the slow-but-not-broken responses room to succeed. Worst-case cycle becomes 20s, steady-state period 25s — still vastly better than the pre-fix baseline.

`CYCLE_WARN_THRESHOLD` bumped 20s → 30s to match (otherwise every healthy 20–25s cycle would log the warning).

## Test plan

- [ ] Deploy, watch journal for 3 min
- [ ] Per-device timeout warnings should drop by 70%+
- [ ] MASTER_BR SK timestamp gaps should shrink (no consecutive timeouts on the same path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)