### PR TITLE
revert(RedLink): REFRESH_DEADLINE 20s → 12s after live regression

### DIFF
--- a/pivac/RedLink.py
+++ b/pivac/RedLink.py
@@ -26,19 +26,20 @@ logger = logging.getLogger(__name__)
 # seconds. Healthy cycles run 5–15s; sustained values above this threshold
 # show up as stale-data flicker in WilhelmSK widgets long before the
 # `redlink-stale-fast` (10m) freshness alert fires.
-CYCLE_WARN_THRESHOLD = 30.0
+CYCLE_WARN_THRESHOLD = 20.0
 
 # Hard per-device deadline for `dev.refresh()`. Independent of the config's
 # `request_timeout` (which governs the aiosomecomfort client used for login —
 # cold-start login on the Pi takes ~75s and must not be cut short). With
 # refreshes parallelised, this is the worst-case cycle time when one device
 # stalls: a single slow thermostat can no longer drag the others past it.
-# 20s gives Honeywell's flaky per-device API enough rope to succeed on the
-# Pi (per-device latency averages 5–10s with occasional 15s+ outliers);
-# tightening this further produced too many false-timeout failures and made
-# specific paths (e.g. MASTER_BR.temperature) flicker stale in WilhelmSK
-# whenever they happened to time out 2–3 cycles in a row.
-REFRESH_DEADLINE = 20.0
+# Empirically tuned: 20s sounds more lenient but produced ~25% per-device
+# failure rate vs 12.5% at 12s, because Honeywell appears to rate-limit
+# parallel requests and longer cycles let the rate-limiter saturate. The
+# longer cycles also caused WebSocket-to-SignalK disconnects mid-cycle.
+# Stick with 12s — failed devices skip a cycle but the cycle itself
+# completes fast and the WS stays warm.
+REFRESH_DEADLINE = 12.0
 
 _loop = None
 _loop_thread = None


### PR DESCRIPTION
## Summary

Reverts the deadline portion of PR #49. Live measurement immediately after deploy showed it made things worse, not better.

| Deadline | Per-device failure rate | Typical cycle time | WebSocket reconnects/3min |
|----------|------------------------|--------------------|--------------------------|
| 12s (PR #48) | ~12.5% | 17s | 1 |
| 20s (PR #49) | ~25% | 22s | 2 |

Honeywell appears to rate-limit parallel requests from one IP. The longer deadline lets more in-flight refreshes accumulate before queueing kicks in, so more end up timing out anyway. The longer cycle also caused WebSocket-to-SignalK disconnects mid-cycle, producing 100s+ gaps on individual SK paths during reconnect windows.

12s is the sweet spot: failed devices skip a cycle, but the cycle itself completes fast and the WS stays warm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)