### PR TITLE
feat: weekly automated SD-card hot-recovery clone via systemd timer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,6 +242,8 @@ Stop order matters: pivac services first (they push to Signal K), then signalk (
 
 `nas-image-backup.timer` runs `nas-image-backup.service` on the 1st of each month at 03:00 EDT. The service runs `scripts/nas-image-backup.sh`, which mounts the NFS share, stops the disk-writing services listed above, runs `image-backup` against `/mnt/nas-pi-backups/pivac.img`, and restarts services on EXIT. Typical incremental: ~2 minutes downtime. See `~/CLAUDE.md` Backup section for the full architecture (NAS share, NFS+ACL gotcha, bootstrap caveats).
 
+`sd-clone.timer` runs `sd-clone.service` weekly (Sunday 02:00 EDT). The service runs `scripts/sd-clone.sh`, which auto-discovers the populated slot of the USB SD reader by model name `NS-DCR30A2`, refuses if the target matches the booted disk, then calls `rpi-clone <target> -U`. No service stop — `rpi-clone` is designed for live cloning. First run repartitions and takes ~30 min; subsequent incrementals are ~3 min. The clone is a directly bootable hot-recovery spare: pull live SD, drop the spare in, reboot. Install dependency: `rpi-clone` from `~/github/rpi-clone` (billw2/rpi-clone), copied to `/usr/local/sbin/`.
+
 ## Checking Logs
 
 ```bash

--- a/scripts/sd-clone.sh
+++ b/scripts/sd-clone.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# Weekly hot-recovery clone of the live Pi filesystem to the USB-attached
+# spare microSD. Used for fast card-death recovery: pull live SD, drop spare
+# in, reboot. rpi-clone runs on a live system; no service stop needed.
+#
+# Triggered by sd-clone.timer; can also be run manually as root.
+set -u -o pipefail
+
+READER_MODEL=NS-DCR30A2
+RPI_CLONE=/usr/local/sbin/rpi-clone
+
+log() { echo "[$(date -Is)] $*"; }
+
+if [[ $EUID -ne 0 ]]; then
+    log "ERROR: must run as root"
+    exit 1
+fi
+
+if [[ ! -x $RPI_CLONE ]]; then
+    log "ERROR: $RPI_CLONE not installed (clone repo at ~/github/rpi-clone, copy to /usr/local/sbin)"
+    exit 1
+fi
+
+# The Insignia NS-DCR30A2 is a 4-LUN reader; only the slot with media has size > 0.
+TARGETS=()
+for blk in /sys/block/sd?; do
+    [[ -e $blk ]] || continue
+    name=$(basename "$blk")
+    model=$(cat "$blk/device/model" 2>/dev/null | tr -d ' ')
+    size=$(cat "$blk/size" 2>/dev/null || echo 0)
+    [[ $model == "$READER_MODEL" ]] || continue
+    [[ $size -gt 0 ]] || continue
+    TARGETS+=("$name")
+done
+
+if [[ ${#TARGETS[@]} -eq 0 ]]; then
+    log "ERROR: no populated $READER_MODEL slot found — is the spare card inserted?"
+    exit 1
+fi
+if [[ ${#TARGETS[@]} -gt 1 ]]; then
+    log "ERROR: multiple populated slots found — refusing to guess: ${TARGETS[*]}"
+    exit 1
+fi
+
+TARGET=${TARGETS[0]}
+log "target: /dev/$TARGET"
+
+ROOT_SRC=$(findmnt -no SOURCE /)
+if [[ $ROOT_SRC == /dev/${TARGET}* ]]; then
+    log "ERROR: target $TARGET is the booted disk — refusing"
+    exit 1
+fi
+
+T0=$(date +%s)
+"$RPI_CLONE" "$TARGET" -U
+RC=$?
+T1=$(date +%s)
+ELAPSED=$((T1 - T0))
+log "rpi-clone finished — exit $RC — elapsed ${ELAPSED}s ($((ELAPSED/60))m $((ELAPSED%60))s)"
+
+exit $RC

--- a/scripts/systemd/sd-clone.service
+++ b/scripts/systemd/sd-clone.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Weekly hot-recovery clone to spare microSD
+Documentation=file:///home/pi/CLAUDE.md
+
+[Service]
+Type=oneshot
+ExecStart=/home/pi/github/pivac/scripts/sd-clone.sh
+TimeoutStartSec=1h
+StandardOutput=journal
+StandardError=journal

--- a/scripts/systemd/sd-clone.timer
+++ b/scripts/systemd/sd-clone.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run sd-clone weekly
+
+[Timer]
+OnCalendar=Sun *-*-* 02:00:00
+Persistent=true
+RandomizedDelaySec=15min
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary
- New `sd-clone.timer` (Sunday 02:00 EDT, +/− 15 min jitter) running `sd-clone.service` → `scripts/sd-clone.sh`
- Script auto-discovers the populated slot of the Insignia NS-DCR30A2 USB SD reader by model name (the 4-LUN reader exposes `/dev/sda`–`/dev/sdd`; only the slot with media has `size > 0`) and refuses if the target somehow matches the booted disk
- Clones live filesystem via `rpi-clone -U` (live-safe, no service stop — unlike the monthly NAS image)
- Updates `CLAUDE.md` Backup Automation section to cover both timers

## Stacked on #44
Base = `feature/nas-backup-timer` because the CLAUDE.md edits build on the Backup Automation section that PR #44 introduces. Will auto-rebase when #44 merges.

## Test plan
- [x] First clone (initialize): 29m 19s, verified bootable layout (boot vfat + root ext4 with PARTUUID-rewritten fstab)
- [x] Incremental via `systemctl start sd-clone.service`: **2m 7s**, exit 0
- [x] Timer enabled, next run scheduled (`systemctl list-timers sd-clone.timer` → Sun 02:06:30 EDT)
- [ ] Boot test (swap cards once, confirm spare boots) — deferred, needs physical access

🤖 Generated with [Claude Code](https://claude.com/claude-code)