### PR TITLE
feat: split outdoor-temp deltas + 1-wire freshness/divergence alerts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,6 +187,10 @@ Grafana's built-in SMTP is disabled (DSM/M365 tenants no longer accept SMTP AUTH
   - `redlink-stale` (warning) — last 30m of `environment.inside.thermostat.MASTER_BR.temperature`. Canonical "definitely broken" signal. `noDataState: Alerting`.
   - `redlink-stale-fast` (info) — same metric, 10m window. Earlier warning that data flow has stopped. `noDataState: Alerting`.
   - `redlink-error-burst` (warning) — fires when `environment.inside.thermostat.redlink.consecutiveErrors > 2` for 5m. Reads the new health-counter the module emits every cycle. `noDataState: OK` (the freshness alerts cover the no-data case). The runbook in the alert directs the responder to query `environment.inside.thermostat.redlink.lastErrorType` to identify the failure mode (e.g. `UnexpectedResponse` = aiosomecomfort can't parse Honeywell's reply, signal that the library or scraper fallback may be needed).
+- `grafana/provisioning/alerting/sensor-freshness.yaml` — 1-wire freshness + outdoor cross-check, group `sensor-data-freshness`, all routing to `graph-bridge`. All temps are stored in **Kelvin**, so the staleness rules reuse the same `value < 100` never-true sentinel as `redlink-stale` and rely on `noDataState: Alerting`:
+  - `hydronic-{in,crw,out}-stale` (warning) — per-sensor 30m staleness on `environment.inside.hvac.{IN,CRW,OUT}.temperature`. One rule each so the email names which sensor dropped (the per-sensor isolation fix means a single bad DS18B20 no longer stales the others). OUT's runbook flags its history of intermittent w1-bus dropouts.
+  - `outside-onewire-stale` (warning) — 30m staleness on `environment.outside.temperature` (the physical AMB DS18B20).
+  - `outside-temp-divergence` (info) — fires when `abs(environment.outside.temperature − environment.outside.thermostat.temperature) > 8 K` (~14 °F) sustained for 1h. Catches a single drifting/failed outdoor sensor while its data is still "fresh". `noDataState: OK` so a thermostat with no outdoor sensor (thermostat path absent) never trips it. Baseline divergence observed ≈1 K.
 
 **Test the bridge end-to-end:**
 ```bash
@@ -202,8 +206,8 @@ sudo cp ~/github/pivac/scripts/systemd/grafana-graph-bridge.service /etc/systemd
 sudo systemctl daemon-reload && sudo systemctl restart grafana-graph-bridge
 # provisioning YAMLs (Grafana copies, not symlinks — must restart to pick up changes):
 sudo cp ~/github/pivac/grafana/provisioning/alerting/*.yaml /etc/grafana/provisioning/alerting/
-sudo chown root:grafana /etc/grafana/provisioning/alerting/{contact-points,redlink-stale}.yaml
-sudo chmod 640         /etc/grafana/provisioning/alerting/{contact-points,redlink-stale}.yaml
+sudo chown root:grafana /etc/grafana/provisioning/alerting/{contact-points,redlink-stale,sensor-freshness}.yaml
+sudo chmod 640         /etc/grafana/provisioning/alerting/{contact-points,redlink-stale,sensor-freshness}.yaml
 sudo systemctl restart grafana-server
 ```
 

--- a/config/config.yml.sample
+++ b/config/config.yml.sample
@@ -80,7 +80,10 @@ pivac.OneWireTherm:
             outname: CRW
         0516a36816ff:
             outname: AMB
-            sk_path: environment.outside.thermostat
+            # Physical outdoor air sensor → canonical Signal K outside-air path.
+            # Kept distinct from the Honeywell-reported environment.outside.thermostat.temperature
+            # (pivac.RedLink) so the two can be cross-checked for divergence.
+            sk_path: environment.outside
             sk_literal: true
         0316a015e7ff:
             outname: Unassigned

--- a/grafana/provisioning/alerting/sensor-freshness.yaml
+++ b/grafana/provisioning/alerting/sensor-freshness.yaml
@@ -1,0 +1,545 @@
+apiVersion: 1
+
+# Freshness + cross-check alerts for the 1-wire hydronic/outside temperatures.
+# Reuses the same graph-bridge contact point as redlink-stale.yaml (Grafana webhook ->
+# scripts/grafana_graph_bridge.py -> Microsoft Graph sendMail -> david@dglc.com).
+#
+# All temperatures are stored in InfluxDB in KELVIN (the Signal K delta unit), so the
+# staleness rules use the same "value < 100" sentinel as redlink-stale: a live temp is
+# always > 100 K, so the threshold is never true while data flows. Detection is driven by
+# noDataState: Alerting — when the metric stops, refId A returns NoData and the rule fires.
+#
+# A separate group name from redlink-stale's "pivac-data-freshness" avoids provisioning
+# collisions.
+groups:
+  - orgId: 1
+    name: sensor-data-freshness
+    folder: pivac
+    interval: 1m
+    rules:
+      # ---- Hydronic water temps: one rule per sensor so we know which one dropped ----
+      - uid: hydronic-in-stale
+        title: Hydronic IN water temp stale (>30m)
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 1800
+              to: 0
+            datasourceUid: bdxaqnfllu5fkf
+            model:
+              datasource:
+                type: influxdb
+                uid: bdxaqnfllu5fkf
+              measurement: environment.inside.hvac.IN.temperature
+              policy: default
+              resultFormat: time_series
+              orderByTime: ASC
+              groupBy:
+                - type: time
+                  params:
+                    - $__interval
+                - type: fill
+                  params:
+                    - none
+              select:
+                - - type: field
+                    params:
+                      - value
+                  - type: mean
+                    params: []
+              tags: []
+              refId: A
+              intervalMs: 60000
+              maxDataPoints: 43200
+          - refId: B
+            relativeTimeRange:
+              from: 1800
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: reduce
+              expression: A
+              reducer: last
+              datasource:
+                type: __expr__
+                uid: __expr__
+              refId: B
+              intervalMs: 1000
+              maxDataPoints: 43200
+          - refId: C
+            relativeTimeRange:
+              from: 1800
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: B
+              datasource:
+                type: __expr__
+                uid: __expr__
+              refId: C
+              conditions:
+                - evaluator:
+                    type: lt
+                    params:
+                      - 100
+                  operator:
+                    type: and
+                  query:
+                    params:
+                      - B
+                  reducer:
+                    type: last
+                  type: query
+              intervalMs: 1000
+              maxDataPoints: 43200
+        noDataState: Alerting
+        execErrState: Alerting
+        for: 1m
+        annotations:
+          summary: "Hydronic IN water temperature has been stale for >30m (environment.inside.hvac.IN.temperature)"
+          runbook: |
+            One or more DS18B20 hydronic sensors have stopped publishing.
+            1. `ls /sys/bus/w1/devices/` — confirm the sensor still enumerates on the w1 bus.
+            2. `journalctl -u pivac-1wire -n 50 --no-pager` — look for repeated "read failed" WARNINGs (per-sensor isolation is in place, so a single bad sensor no longer stales the others) or a NoSensorFoundError crash-loop at import.
+            3. If a sensor dropped off the bus entirely, a `sudo reboot` is currently the only reliable recovery (modprobe-reload does not recover an unreliable bus). See CLAUDE.md "OneWireTherm per-sensor isolation".
+        labels:
+          severity: warning
+          source: onewire
+        isPaused: false
+        notification_settings:
+          receiver: graph-bridge
+
+      - uid: hydronic-crw-stale
+        title: Hydronic CRW water temp stale (>30m)
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 1800
+              to: 0
+            datasourceUid: bdxaqnfllu5fkf
+            model:
+              datasource:
+                type: influxdb
+                uid: bdxaqnfllu5fkf
+              measurement: environment.inside.hvac.CRW.temperature
+              policy: default
+              resultFormat: time_series
+              orderByTime: ASC
+              groupBy:
+                - type: time
+                  params:
+                    - $__interval
+                - type: fill
+                  params:
+                    - none
+              select:
+                - - type: field
+                    params:
+                      - value
+                  - type: mean
+                    params: []
+              tags: []
+              refId: A
+              intervalMs: 60000
+              maxDataPoints: 43200
+          - refId: B
+            relativeTimeRange:
+              from: 1800
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: reduce
+              expression: A
+              reducer: last
+              datasource:
+                type: __expr__
+                uid: __expr__
+              refId: B
+              intervalMs: 1000
+              maxDataPoints: 43200
+          - refId: C
+            relativeTimeRange:
+              from: 1800
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: B
+              datasource:
+                type: __expr__
+                uid: __expr__
+              refId: C
+              conditions:
+                - evaluator:
+                    type: lt
+                    params:
+                      - 100
+                  operator:
+                    type: and
+                  query:
+                    params:
+                      - B
+                  reducer:
+                    type: last
+                  type: query
+              intervalMs: 1000
+              maxDataPoints: 43200
+        noDataState: Alerting
+        execErrState: Alerting
+        for: 1m
+        annotations:
+          summary: "Hydronic CRW water temperature has been stale for >30m (environment.inside.hvac.CRW.temperature)"
+          runbook: "Same triage as hydronic-in-stale — see that rule's runbook and CLAUDE.md 'OneWireTherm per-sensor isolation'."
+        labels:
+          severity: warning
+          source: onewire
+        isPaused: false
+        notification_settings:
+          receiver: graph-bridge
+
+      - uid: hydronic-out-stale
+        title: Hydronic OUT water temp stale (>30m)
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 1800
+              to: 0
+            datasourceUid: bdxaqnfllu5fkf
+            model:
+              datasource:
+                type: influxdb
+                uid: bdxaqnfllu5fkf
+              measurement: environment.inside.hvac.OUT.temperature
+              policy: default
+              resultFormat: time_series
+              orderByTime: ASC
+              groupBy:
+                - type: time
+                  params:
+                    - $__interval
+                - type: fill
+                  params:
+                    - none
+              select:
+                - - type: field
+                    params:
+                      - value
+                  - type: mean
+                    params: []
+              tags: []
+              refId: A
+              intervalMs: 60000
+              maxDataPoints: 43200
+          - refId: B
+            relativeTimeRange:
+              from: 1800
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: reduce
+              expression: A
+              reducer: last
+              datasource:
+                type: __expr__
+                uid: __expr__
+              refId: B
+              intervalMs: 1000
+              maxDataPoints: 43200
+          - refId: C
+            relativeTimeRange:
+              from: 1800
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: B
+              datasource:
+                type: __expr__
+                uid: __expr__
+              refId: C
+              conditions:
+                - evaluator:
+                    type: lt
+                    params:
+                      - 100
+                  operator:
+                    type: and
+                  query:
+                    params:
+                      - B
+                  reducer:
+                    type: last
+                  type: query
+              intervalMs: 1000
+              maxDataPoints: 43200
+        noDataState: Alerting
+        execErrState: Alerting
+        for: 1m
+        annotations:
+          summary: "Hydronic OUT water temperature has been stale for >30m (environment.inside.hvac.OUT.temperature)"
+          runbook: |
+            Same triage as hydronic-in-stale. NOTE: the OUT sensor (0516a365d8ff) has a
+            history of intermittently dropping off the w1 bus and re-enumerating after a
+            reboot. If only OUT is stale (IN/CRW fresh), suspect that physical sensor at the
+            hydronic loop before suspecting the module.
+        labels:
+          severity: warning
+          source: onewire
+        isPaused: false
+        notification_settings:
+          receiver: graph-bridge
+
+      # ---- Outside air (physical DS18B20) freshness ----
+      - uid: outside-onewire-stale
+        title: Outside air temp (1-wire) stale (>30m)
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 1800
+              to: 0
+            datasourceUid: bdxaqnfllu5fkf
+            model:
+              datasource:
+                type: influxdb
+                uid: bdxaqnfllu5fkf
+              measurement: environment.outside.temperature
+              policy: default
+              resultFormat: time_series
+              orderByTime: ASC
+              groupBy:
+                - type: time
+                  params:
+                    - $__interval
+                - type: fill
+                  params:
+                    - none
+              select:
+                - - type: field
+                    params:
+                      - value
+                  - type: mean
+                    params: []
+              tags: []
+              refId: A
+              intervalMs: 60000
+              maxDataPoints: 43200
+          - refId: B
+            relativeTimeRange:
+              from: 1800
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: reduce
+              expression: A
+              reducer: last
+              datasource:
+                type: __expr__
+                uid: __expr__
+              refId: B
+              intervalMs: 1000
+              maxDataPoints: 43200
+          - refId: C
+            relativeTimeRange:
+              from: 1800
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: B
+              datasource:
+                type: __expr__
+                uid: __expr__
+              refId: C
+              conditions:
+                - evaluator:
+                    type: lt
+                    params:
+                      - 100
+                  operator:
+                    type: and
+                  query:
+                    params:
+                      - B
+                  reducer:
+                    type: last
+                  type: query
+              intervalMs: 1000
+              maxDataPoints: 43200
+        noDataState: Alerting
+        execErrState: Alerting
+        for: 1m
+        annotations:
+          summary: "Outside air temperature (1-wire AMB) stale for >30m (environment.outside.temperature)"
+          runbook: "The AMB DS18B20 has stopped publishing. Same w1-bus triage as hydronic-in-stale. RedLink's environment.outside.thermostat.temperature is an independent source if you need an outdoor reading meanwhile."
+        labels:
+          severity: warning
+          source: onewire
+        isPaused: false
+        notification_settings:
+          receiver: graph-bridge
+
+      # ---- Cross-check: physical 1-wire vs Honeywell-reported outdoor temp ----
+      # Both stored in Kelvin. Fires when the two sources disagree by > 8 K (~14.4 F)
+      # sustained for 1h — a generous threshold that tolerates normal sensor-placement
+      # offsets (baseline divergence observed ~1 K) but catches a single drifting/failed
+      # sensor while its data is still nominally "fresh". noDataState: OK so a thermostat
+      # with no outdoor sensor (thermostat.temperature absent) never trips this rule.
+      - uid: outside-temp-divergence
+        title: Outside temp sources diverging (1-wire vs thermostat)
+        condition: F
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 1800
+              to: 0
+            datasourceUid: bdxaqnfllu5fkf
+            model:
+              datasource:
+                type: influxdb
+                uid: bdxaqnfllu5fkf
+              measurement: environment.outside.temperature
+              policy: default
+              resultFormat: time_series
+              orderByTime: ASC
+              groupBy:
+                - type: time
+                  params:
+                    - $__interval
+                - type: fill
+                  params:
+                    - none
+              select:
+                - - type: field
+                    params:
+                      - value
+                  - type: mean
+                    params: []
+              tags: []
+              refId: A
+              intervalMs: 60000
+              maxDataPoints: 43200
+          - refId: B
+            relativeTimeRange:
+              from: 1800
+              to: 0
+            datasourceUid: bdxaqnfllu5fkf
+            model:
+              datasource:
+                type: influxdb
+                uid: bdxaqnfllu5fkf
+              measurement: environment.outside.thermostat.temperature
+              policy: default
+              resultFormat: time_series
+              orderByTime: ASC
+              groupBy:
+                - type: time
+                  params:
+                    - $__interval
+                - type: fill
+                  params:
+                    - none
+              select:
+                - - type: field
+                    params:
+                      - value
+                  - type: mean
+                    params: []
+              tags: []
+              refId: B
+              intervalMs: 60000
+              maxDataPoints: 43200
+          - refId: C
+            relativeTimeRange:
+              from: 1800
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: reduce
+              expression: A
+              reducer: last
+              datasource:
+                type: __expr__
+                uid: __expr__
+              refId: C
+              intervalMs: 1000
+              maxDataPoints: 43200
+          - refId: D
+            relativeTimeRange:
+              from: 1800
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: reduce
+              expression: B
+              reducer: last
+              datasource:
+                type: __expr__
+                uid: __expr__
+              refId: D
+              intervalMs: 1000
+              maxDataPoints: 43200
+          - refId: E
+            relativeTimeRange:
+              from: 1800
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: math
+              expression: abs($C - $D)
+              datasource:
+                type: __expr__
+                uid: __expr__
+              refId: E
+              intervalMs: 1000
+              maxDataPoints: 43200
+          - refId: F
+            relativeTimeRange:
+              from: 1800
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: E
+              datasource:
+                type: __expr__
+                uid: __expr__
+              refId: F
+              conditions:
+                - evaluator:
+                    type: gt
+                    params:
+                      - 8
+                  operator:
+                    type: and
+                  query:
+                    params:
+                      - E
+                  reducer:
+                    type: last
+                  type: query
+              intervalMs: 1000
+              maxDataPoints: 43200
+        noDataState: OK
+        execErrState: OK
+        for: 1h
+        annotations:
+          summary: "Outdoor temp sources disagree by >8 K (~14 F) for 1h — one sensor is likely drifting or failed"
+          runbook: |
+            environment.outside.temperature (physical DS18B20 / AMB) and
+            environment.outside.thermostat.temperature (Honeywell-reported) have diverged
+            beyond the sanity threshold while both are still publishing. This catches a
+            single bad sensor that staleness alerts would miss (data is fresh, just wrong).
+            1. Compare both series in Grafana over the last few hours — which one stepped or drifted?
+            2. The DS18B20 is the local physical sensor; the thermostat value is whatever Honeywell reports (may lag or be a different microclimate).
+            3. If the 1-wire reads implausibly, inspect the AMB sensor wiring; if the thermostat value is stuck, it's a Honeywell-side issue.
+        labels:
+          severity: info
+          source: crosscheck
+        isPaused: false
+        notification_settings:
+          receiver: graph-bridge

--- a/pivac/RedLink.py
+++ b/pivac/RedLink.py
@@ -290,6 +290,8 @@ def status(config={}, output="default"):
 
     result = {}
     outdoor_humidity_pct = None
+    outdoor_temp_raw = None
+    outdoor_temp_scale = None
 
     for dev in devices:
         name = dev.name or str(dev.deviceid)
@@ -314,6 +316,14 @@ def status(config={}, output="default"):
 
         if dev.outdoor_humidity is not None and outdoor_humidity_pct is None:
             outdoor_humidity_pct = float(dev.outdoor_humidity)
+
+        # Honeywell-reported outdoor temperature (gated on OutdoorTemperatureAvailable
+        # inside aiosomecomfort; returns None when the thermostat has no outdoor sensor).
+        # Published to the .thermostat. node alongside humidity so it can be cross-checked
+        # against the physical DS18B20 published to environment.outside.temperature.
+        if dev.outdoor_temperature is not None and outdoor_temp_raw is None:
+            outdoor_temp_raw = float(dev.outdoor_temperature)
+            outdoor_temp_scale = scale
 
         if output == "signalk":
             sk_add_value(sk_source, f"{inside_path}.{fname}.temperature", int(ktemp))
@@ -340,8 +350,12 @@ def status(config={}, output="default"):
     if output == "signalk":
         if outdoor_humidity_pct is not None:
             sk_add_value(sk_source, f"{outside_path}.humidity", outdoor_humidity_pct / 100.0)
+        if outdoor_temp_raw is not None:
+            sk_add_value(sk_source, f"{outside_path}.temperature", int(_to_kelvin(outdoor_temp_raw, outdoor_temp_scale)))
         return deltas
 
     if outdoor_humidity_pct is not None:
         result["outhum"] = outdoor_humidity_pct
+    if outdoor_temp_raw is not None:
+        result["outtemp"] = outdoor_temp_raw
     return result


### PR DESCRIPTION
## Background

Two independent outdoor-temperature sources were being conflated:
- The **physical DS18B20** (AMB) published to `environment.outside.thermostat.temperature` — implying thermostat provenance, sitting right next to RedLink's `environment.outside.thermostat.humidity`.
- **RedLink never published an outdoor temperature at all** — only humidity. So the intended "double-check AMB against the thermostat" cross-check was never actually wired up (the prior session note's "last-writer-wins collision" was a misdiagnosis — there was no temperature collision).

## Changes

**1. Split the outdoor-temp deltas by provenance** (so they can be cross-checked):

| Source | Path | Change |
|---|---|---|
| DS18B20 (physical) | `environment.outside.temperature` | canonical SK outside-air; `sk_path` change in `config.yml.sample` + live `/etc/pivac/config.yml` |
| Honeywell (reported) | `environment.outside.thermostat.temperature` | **NEW** — RedLink now reads `dev.outdoor_temperature` (gated on `OutdoorTemperatureAvailable`), emitted alongside the existing humidity |

**2. `grafana/provisioning/alerting/sensor-freshness.yaml`** (group `sensor-data-freshness`, reusing the existing `graph-bridge` → Microsoft Graph `sendMail` email path):
- `hydronic-{in,crw,out}-stale` — per-sensor 30m staleness on the hydronic water temps (one rule each so the email names which sensor dropped).
- `outside-onewire-stale` — 30m staleness on the AMB outside-air temp.
- `outside-temp-divergence` — fires when the two outdoor sources disagree by **>8 K (~14 °F) for 1h**, catching a single drifting/failed sensor while its data is still nominally "fresh". `noDataState: OK` so a thermostat with no outdoor sensor never trips it.

All temps are stored in **Kelvin**, so the staleness rules reuse the same `value < 100` never-true sentinel as `redlink-stale` and rely on `noDataState: Alerting`.

## Verification (on the Pi)

- Both outdoor paths now populate distinctly: `environment.outside.temperature` = 285 K, `environment.outside.thermostat.temperature` = 284 K (~1.8 °F baseline divergence — confirms Honeywell does report outdoor temp).
- All 5 new rules provisioned into Grafana (confirmed via `alert_rule` table) with **no eval errors**; live config + both modules YAML/syntax-validated.

## Boundaries / not in scope

- Does **not** add an external (off-Pi) dead-man's switch — these Grafana alerts can't self-report a total Pi hang (Grafana+Influx must be alive). Flagged for a possible follow-up.
- Live `/etc/pivac/config.yml` is already updated on the Pi (not version-controlled; the repo carries the sample).

🤖 Generated with [Claude Code](https://claude.com/claude-code)