### PR TITLE
fix(grafana): plot DHW recirc temp on the shared left axis

### DIFF
--- a/grafana/dashboards/pivacr.json
+++ b/grafana/dashboards/pivacr.json
@@ -2225,7 +2225,7 @@
             "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
-            "axisLabel": "psi",
+            "axisLabel": "PSI + °F",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "barWidthFactor": 0.6,
@@ -2278,15 +2278,7 @@
             "properties": [
               {
                 "id": "custom.axisPlacement",
-                "value": "right"
-              },
-              {
-                "id": "unit",
-                "value": "fahrenheit"
-              },
-              {
-                "id": "custom.axisLabel",
-                "value": "Recirc \u00b0F"
+                "value": "left"
               },
               {
                 "id": "color",


### PR DESCRIPTION
## Problem

The "Potable DHW Loop — Pressure & Recirc Temp" panel (id 5) plotted recirc temperature on a **right-hand** y-axis. The render path in use can't display right-side axis labels, but the temp trace still needs to stay on the chart.

## Change

Move the recirc-temp series onto the existing **left** (PSI) axis:
- Relabel the left axis `psi` → `PSI + °F`.
- Drop the temp series' separate `fahrenheit` unit so both series share one numeric scale. PSI (~64) and recirc °F (~100–130) are close enough to read on a common axis.
- Temp keeps its orange color and is named in the legend, so the two traces stay distinguishable.

No data, query, or K→°F conversion change — purely axis/label presentation. Dashboard is provisioned, so this auto-applies within ~30s of `git pull` on the Pi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)