### PR TITLE
fix(grafana): force DHW PSI + recirc temp onto one shared y-axis

### DIFF
--- a/grafana/dashboards/pivacr.json
+++ b/grafana/dashboards/pivacr.json
@@ -2226,7 +2226,7 @@
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "PSI + °F",
-            "axisPlacement": "auto",
+            "axisPlacement": "left",
             "barAlignment": 0,
             "barWidthFactor": 0.6,
             "drawStyle": "line",
@@ -2276,10 +2276,6 @@
               "options": "environment.inside.hvac.dhw.recirc.temperature.mean"
             },
             "properties": [
-              {
-                "id": "custom.axisPlacement",
-                "value": "left"
-              },
               {
                 "id": "color",
                 "value": {


### PR DESCRIPTION
## Problem

After #65 the DHW panel still showed the two series on **different numeric scales** and a doubled left margin. Root cause: the PSI series used `axisPlacement: auto` while the temp override set `left`. Grafana doesn't dedupe an `auto` axis against an explicit `left` one, so it drew **two stacked left axes**, each independently auto-scaled.

## Change

- Panel default `axisPlacement`: `auto` → `left`.
- Removed the redundant per-series `custom.axisPlacement: left` override on the temp series (kept its orange color).

Both series now share **one** auto-scaled left axis: a single scale covering PSI (~64) and recirc °F (~110) together, and a single set of tick labels (reclaims the doubled margin). Provisioned dashboard — auto-applies ~30s after pull.

🤖 Generated with [Claude Code](https://claude.com/claude-code)